### PR TITLE
Add configuration parameters

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Galaxy Tools (VS Code Extension) Changelog
 
+## Unreleased
+
+### Added
+
+- Settings to control completion features.
+
 ## [0.1.2] - 2020-10-25
 
 ### Changed

--- a/client/README.md
+++ b/client/README.md
@@ -48,3 +48,28 @@ Whenever you write a closing ``>`` the corresponding closing tag will be inserte
 
 Snippets can be really helpful to speed up your tool wrapper development. They allow to quickly create common blocks and let you enter just the important information by pressing ``tab`` and navigating to the next available value.
 >If you want to add more snippets check the [guide](./docs/CONTRIBUTING.md#adding-snippets) in the contribution guidelines.
+
+
+# Configuration
+You can customize some of the features with various settings either placing them in the settings.json file in your workspace or editing them through the Settings Editor UI.
+
+## Completion: mode
+This setting controls the auto-completion of tags and attributes. You can choose between three different options:
+- `auto`: shows suggestions as you type. This is the default option.
+- `invoke`: shows suggestions only when you request them using the key shortcut (`Ctrl + space`)
+- `disabled`: completely disables the auto-completion feature.
+
+````json
+{
+    "galaxyTools.completion.mode": "invoke",
+}
+````
+
+## Completion: auto close tags
+This setting ontrols whether to auto-insert the closing tag after typing `>` or `/`.
+
+````json
+{
+    "galaxyTools.completion.autoCloseTags": false
+}
+````

--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,12 @@
             "No suggestions will be shown."
           ],
           "default": "auto"
+        },
+        "galaxyTools.completion.autoCloseTags": {
+          "scope": "resource",
+          "type": "boolean",
+          "markdownDescription": "Controls whether to auto-insert the closing tag after typing `>` or `/`.",
+          "default": "true"
         }
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "author": "davelopez",
   "publisher": "davelopez",
   "license": "Apache-2.0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "preview": true,
   "repository": {
     "type": "git",
@@ -32,8 +32,25 @@
     "commands": [],
     "configuration": {
       "type": "object",
-      "title": "Galaxy Tools Configuration",
-      "properties": {}
+      "title": "Galaxy Tools",
+      "properties": {
+        "galaxyTools.completion.mode": {
+          "scope": "resource",
+          "type": "string",
+          "description": "Controls the auto-completion suggestions.",
+          "enum": [
+            "auto",
+            "invoke",
+            "disabled"
+          ],
+          "markdownEnumDescriptions": [
+            "The appropriate name of elements and attributes, depending on the context, will be automatically suggested as you type.",
+            "The suggestions will appear only if you explicitly invoke them using the `trigger suggest shortcut` (usually `Ctrl + space`).",
+            "No suggestions will be shown."
+          ],
+          "default": "auto"
+        }
+      }
     },
     "snippets": [
       {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import * as net from "net";
-import { ExtensionContext, window, TextDocument, Position, IndentAction, LanguageConfiguration, languages } from "vscode";
+import { ExtensionContext, window, TextDocument, Position, IndentAction, LanguageConfiguration, languages, ExtensionMode } from "vscode";
 import { LanguageClient, LanguageClientOptions, ServerOptions } from "vscode-languageclient";
 import { activateTagClosing, TagCloseRequest } from './tagClosing';
 import { installLanguageServer } from './setup';
@@ -14,7 +14,7 @@ let client: LanguageClient;
  * @param context The extension context
  */
 export async function activate(context: ExtensionContext) {
-  if (isDebugMode()) {
+  if (context.extensionMode === ExtensionMode.Development) {
     // Development - Connect to language server (already running) using TCP
     client = connectToLanguageServerTCP(2087);
   } else {
@@ -61,10 +61,6 @@ function getClientOptions(): LanguageClientOptions {
 
     },
   };
-}
-
-function isDebugMode(): boolean {
-  return process.env.VSCODE_DEBUG_MODE === "true";
 }
 
 /**

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Client settings loading on initialization.
+- Using settings to control completion features.
+
 ### Changed
 
 - The XML parser has been replaced for a better implementation.

--- a/server/galaxyls/config.py
+++ b/server/galaxyls/config.py
@@ -1,0 +1,28 @@
+from typing import Any, Optional
+
+
+from enum import Enum, unique
+
+
+@unique
+class CompletionMode(Enum):
+    """Supported types of XML documents."""
+
+    AUTO = "auto"
+    INVOKE = "invoke"
+    DISABLED = "disabled"
+
+
+class GalaxyToolsConfiguration:
+
+    SECTION = "galaxyTools"
+
+    def __init__(self, config: Optional[Any] = None) -> None:
+        self._config = config
+
+    @property
+    def completion_mode(self) -> CompletionMode:
+        try:
+            return self._config.completion.mode
+        except BaseException:
+            return CompletionMode.AUTO

--- a/server/galaxyls/config.py
+++ b/server/galaxyls/config.py
@@ -18,13 +18,18 @@ class GalaxyToolsConfiguration:
     def __init__(self, config: Optional[Any] = None) -> None:
         self._config = config
         self._completion_mode = self._to_completion_mode(self._config.completion.mode)
+        self._auto_close_tags = self._config.completion.autoCloseTags == "true"
 
     @property
     def completion_mode(self) -> CompletionMode:
         return self._completion_mode
 
+    @property
+    def auto_close_tags(self) -> bool:
+        return self._config.completion.autoCloseTags
+
     def _to_completion_mode(self, setting: str) -> CompletionMode:
         try:
             return CompletionMode[setting.upper()]
-        except BaseException as e:
+        except BaseException:
             return CompletionMode.AUTO

--- a/server/galaxyls/config.py
+++ b/server/galaxyls/config.py
@@ -1,16 +1,14 @@
-from typing import Any, Optional
-
-
 from enum import Enum, unique
+from typing import Any, Optional
 
 
 @unique
 class CompletionMode(Enum):
     """Supported types of XML documents."""
 
-    AUTO = "auto"
-    INVOKE = "invoke"
-    DISABLED = "disabled"
+    AUTO = 1
+    INVOKE = 2
+    DISABLED = 3
 
 
 class GalaxyToolsConfiguration:
@@ -19,10 +17,14 @@ class GalaxyToolsConfiguration:
 
     def __init__(self, config: Optional[Any] = None) -> None:
         self._config = config
+        self._completion_mode = self._to_completion_mode(self._config.completion.mode)
 
     @property
     def completion_mode(self) -> CompletionMode:
+        return self._completion_mode
+
+    def _to_completion_mode(self, setting: str) -> CompletionMode:
         try:
-            return self._config.completion.mode
-        except BaseException:
+            return CompletionMode[setting.upper()]
+        except BaseException as e:
             return CompletionMode.AUTO

--- a/server/galaxyls/config.py
+++ b/server/galaxyls/config.py
@@ -18,7 +18,7 @@ class GalaxyToolsConfiguration:
     def __init__(self, config: Optional[Any] = None) -> None:
         self._config = config
         self._completion_mode = self._to_completion_mode(self._config.completion.mode)
-        self._auto_close_tags = self._config.completion.autoCloseTags == "true"
+        self._auto_close_tags: bool = self._config.completion.autoCloseTags == "true"
 
     @property
     def completion_mode(self) -> CompletionMode:
@@ -26,7 +26,7 @@ class GalaxyToolsConfiguration:
 
     @property
     def auto_close_tags(self) -> bool:
-        return self._config.completion.autoCloseTags
+        return self._auto_close_tags
 
     def _to_completion_mode(self, setting: str) -> CompletionMode:
         try:

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -94,8 +94,9 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
 @language_server.feature(AUTO_CLOSE_TAGS)
 def auto_close_tag(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[AutoCloseTagResult]:
     """Responds to a close tag request to close the currently opened node."""
-    document = server.workspace.get_document(params.textDocument.uri)
-    return server.service.get_auto_close_tag(document, params)
+    if server.configuration.auto_close_tags:
+        document = server.workspace.get_document(params.textDocument.uri)
+        return server.service.get_auto_close_tag(document, params)
 
 
 @language_server.feature(HOVER)

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -1,30 +1,40 @@
 """Galaxy Tools Language Server implementation
 """
 
-from .services.language import GalaxyToolLanguageService
-from .features import AUTO_CLOSE_TAGS
-from .types import AutoCloseTagResult
-from typing import Optional, List
-from pygls.server import LanguageServer
+from typing import List, Optional
+
 from pygls.features import (
     COMPLETION,
     FORMATTING,
     HOVER,
+    INITIALIZED,
     TEXT_DOCUMENT_DID_CLOSE,
     TEXT_DOCUMENT_DID_OPEN,
     TEXT_DOCUMENT_DID_SAVE,
+    WORKSPACE_DID_CHANGE_CONFIGURATION,
 )
+from pygls.server import LanguageServer
 from pygls.types import (
     CompletionList,
     CompletionParams,
+    ConfigurationItem,
+    ConfigurationParams,
+    DidChangeConfigurationParams,
     DidCloseTextDocumentParams,
     DidOpenTextDocumentParams,
     DidSaveTextDocumentParams,
     DocumentFormattingParams,
     Hover,
+    InitializeParams,
+    MessageType,
     TextDocumentPositionParams,
     TextEdit,
 )
+
+from .config import GalaxyToolsConfiguration
+from .features import AUTO_CLOSE_TAGS
+from .services.language import GalaxyToolLanguageService
+from .types import AutoCloseTagResult
 
 SERVER_NAME = "Galaxy Tools LS"
 
@@ -35,9 +45,41 @@ class GalaxyToolsLanguageServer(LanguageServer):
     def __init__(self):
         super().__init__()
         self.service = GalaxyToolLanguageService(SERVER_NAME)
+        self.configuration: GalaxyToolsConfiguration
 
 
 language_server = GalaxyToolsLanguageServer()
+
+
+async def _load_client_config_async(server: GalaxyToolsLanguageServer) -> None:
+    """Loads the client configuration from user or workspace settings and updates
+    the language server configuration.
+
+    Args:
+        server (GalaxyToolsLanguageServer): The language server instance.
+    """
+    try:
+        config = await server.get_configuration_async(
+            ConfigurationParams([ConfigurationItem(section=GalaxyToolsConfiguration.SECTION)])
+        )
+        server.configuration = GalaxyToolsConfiguration(config[0])
+    except BaseException as err:
+        server.configuration = GalaxyToolsConfiguration()
+        server.show_message_log(f"Error loading configuration: {err}")
+        server.show_message("Error loading configuration. Using default settings.", MessageType.Error)
+
+
+@language_server.feature(INITIALIZED)
+async def initialized(server: GalaxyToolsLanguageServer, params: InitializeParams) -> None:
+    """Loads the client configuration after initialization."""
+    await _load_client_config_async(server)
+
+
+@language_server.feature(WORKSPACE_DID_CHANGE_CONFIGURATION)
+def did_change_configuration(server: GalaxyToolsLanguageServer, params: DidChangeConfigurationParams):
+    """Loads the client configuration after a change."""
+    server.show_message("did_change_configuration")
+    _load_client_config_async(server)
 
 
 @language_server.feature(COMPLETION, trigger_characters=["<", " "])
@@ -48,27 +90,21 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
 
 
 @language_server.feature(AUTO_CLOSE_TAGS)
-def auto_close_tag(
-    server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams
-) -> AutoCloseTagResult:
+def auto_close_tag(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[AutoCloseTagResult]:
     """Responds to a close tag request to close the currently opened node."""
     document = server.workspace.get_document(params.textDocument.uri)
     return server.service.get_auto_close_tag(document, params)
 
 
 @language_server.feature(HOVER)
-def hover(
-    server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams
-) -> Optional[Hover]:
+def hover(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[Hover]:
     """Displays Markdown documentation for the element under the cursor."""
     document = server.workspace.get_document(params.textDocument.uri)
     return server.service.get_documentation(document, params.position)
 
 
 @language_server.feature(FORMATTING)
-def formatting(
-    server: GalaxyToolsLanguageServer, params: DocumentFormattingParams
-) -> List[TextEdit]:
+def formatting(server: GalaxyToolsLanguageServer, params: DocumentFormattingParams) -> List[TextEdit]:
     """Formats the whole document using the provided parameters"""
     document = server.workspace.get_document(params.textDocument.uri)
     content = document.source

--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -28,7 +28,7 @@ class XmlCompletionService:
         self.xsd_tree: XsdTree = xsd_tree
 
     def get_completion_at_context(
-        self, context: XmlContext, completion_context: CompletionContext, mode: CompletionMode
+        self, context: XmlContext, completion_context: CompletionContext, mode: CompletionMode = CompletionMode.AUTO
     ) -> CompletionList:
         triggerKind = completion_context.triggerKind
         if mode == CompletionMode.AUTO and triggerKind == CompletionTriggerKind.TriggerCharacter:
@@ -40,7 +40,9 @@ class XmlCompletionService:
             if context.is_attribute_value:
                 return self.get_attribute_value_completion(context)
             if context.is_tag:
-                return self.get_attribute_completion(context)
+                if context.token.name:
+                    return self.get_attribute_completion(context)
+                return self.get_node_completion(context)
         return CompletionList(items=[], is_incomplete=False)
 
     def get_node_completion(self, context: XmlContext) -> CompletionList:

--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -1,6 +1,7 @@
 """Module in charge of the auto-completion feature."""
 
 from typing import Optional
+
 from pygls.types import (
     CompletionContext,
     CompletionItem,
@@ -12,9 +13,10 @@ from pygls.types import (
     Range,
 )
 
-from .xsd.parser import XsdTree, XsdNode, XsdAttribute
-from .context import XmlContext
+from ..config import CompletionMode
 from ..types import AutoCloseTagResult
+from .context import XmlContext
+from .xsd.parser import XsdAttribute, XsdNode, XsdTree
 
 
 class XmlCompletionService:
@@ -25,9 +27,11 @@ class XmlCompletionService:
     def __init__(self, xsd_tree: XsdTree):
         self.xsd_tree: XsdTree = xsd_tree
 
-    def get_completion_at_context(self, context: XmlContext, completion_context: CompletionContext) -> CompletionList:
+    def get_completion_at_context(
+        self, context: XmlContext, completion_context: CompletionContext, mode: CompletionMode
+    ) -> CompletionList:
         triggerKind = completion_context.triggerKind
-        if triggerKind == CompletionTriggerKind.TriggerCharacter:
+        if mode == CompletionMode.AUTO and triggerKind == CompletionTriggerKind.TriggerCharacter:
             if completion_context.triggerCharacter == "<":
                 return self.get_node_completion(context)
             if completion_context.triggerCharacter == " ":

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -1,10 +1,5 @@
-from .xsd.service import GalaxyToolXsdService
-from .format import GalaxyToolFormatService
-from .completion import XmlCompletionService, AutoCloseTagResult
-from .context import XmlContextService
-
 from typing import List, Optional
-from pygls.workspace import Document
+
 from pygls.types import (
     CompletionList,
     CompletionParams,
@@ -15,6 +10,13 @@ from pygls.types import (
     TextDocumentPositionParams,
     TextEdit,
 )
+from pygls.workspace import Document
+
+from ..config import CompletionMode
+from .completion import AutoCloseTagResult, XmlCompletionService
+from .context import XmlContextService
+from .format import GalaxyToolFormatService
+from .xsd.service import GalaxyToolXsdService
 
 
 class GalaxyToolLanguageService:
@@ -52,10 +54,10 @@ class GalaxyToolLanguageService:
         """
         return self.format_service.format(content, params)
 
-    def get_completion(self, document: Document, params: CompletionParams) -> CompletionList:
+    def get_completion(self, document: Document, params: CompletionParams, mode: CompletionMode) -> CompletionList:
         """Gets completion items depending on the current document context."""
         context = self.xml_context_service.get_xml_context(document, params.position)
-        return self.completion_service.get_completion_at_context(context, params.context)
+        return self.completion_service.get_completion_at_context(context, params.context, mode)
 
     def get_auto_close_tag(self, document: Document, params: TextDocumentPositionParams) -> Optional[AutoCloseTagResult]:
         """Gets the closing result for the currently opened tag in context."""

--- a/server/galaxyls/tests/unit/test_completion.py
+++ b/server/galaxyls/tests/unit/test_completion.py
@@ -71,11 +71,24 @@ class TestXmlCompletionServiceClass:
 
         assert service.xsd_tree
 
-    def test_get_completion_at_context_with_open_tag_trigger_returns_expected_node(
-        self, fake_tree: XsdTree, mocker: MockerFixture
-    ) -> None:
+    def test_get_completion_at_context_with_open_tag_trigger_returns_expected_node(self, fake_tree: XsdTree) -> None:
         fake_context = XmlContext(fake_tree.root, XmlElement())
         fake_completion_context = CompletionContext(CompletionTriggerKind.TriggerCharacter, trigger_character="<")
+        service = XmlCompletionService(fake_tree)
+
+        actual = service.get_completion_at_context(fake_context, fake_completion_context)
+
+        assert actual
+        assert len(actual.items) == 2
+        assert actual.items[0].label == "child"
+        assert actual.items[0].kind == CompletionItemKind.Class
+        assert actual.items[1].label == "expand"
+        assert actual.items[1].kind == CompletionItemKind.Class
+
+    def test_get_completion_at_context_with_open_tag_invoke_returns_expected_node(self, fake_tree: XsdTree) -> None:
+        fake_element = XmlElement()
+        fake_context = XmlContext(fake_tree.root, fake_element)
+        fake_completion_context = CompletionContext(CompletionTriggerKind.Invoked)
         service = XmlCompletionService(fake_tree)
 
         actual = service.get_completion_at_context(fake_context, fake_completion_context)

--- a/server/galaxyls/tests/unit/test_config.py
+++ b/server/galaxyls/tests/unit/test_config.py
@@ -1,0 +1,25 @@
+from typing import Any, NamedTuple
+
+from pytest_mock.plugin import MockerFixture
+
+from ...config import CompletionMode, GalaxyToolsConfiguration
+
+
+class TestGalaxyToolsConfigurationClass:
+    def test_init_sets_properties(self, mocker: MockerFixture) -> None:
+        mock_config = mocker.Mock()
+        mock_config.completion.mode = "invoke"
+        mock_config.completion.autoCloseTags = "false"
+
+        config = GalaxyToolsConfiguration(mock_config)
+
+        assert config.completion_mode
+        assert not config.auto_close_tags
+
+    def test_unknown_completion_mode_returns_default(self, mocker: MockerFixture) -> None:
+        mock_config = mocker.Mock()
+        mock_config.completion.mode = "unknown"
+
+        config = GalaxyToolsConfiguration(mock_config)
+
+        assert config.completion_mode == CompletionMode.AUTO

--- a/server/galaxyls/tests/unit/test_config.py
+++ b/server/galaxyls/tests/unit/test_config.py
@@ -1,5 +1,3 @@
-from typing import Any, NamedTuple
-
 from pytest_mock.plugin import MockerFixture
 
 from ...config import CompletionMode, GalaxyToolsConfiguration


### PR DESCRIPTION
The language server now loads the client configuration when it is initialized and uses the settings to control some of the features.
In particular, two settings have been added to the extension to control the auto-completion feature.

![image](https://user-images.githubusercontent.com/46503462/98741244-9b31a080-23ac-11eb-9850-8f9a25c633b1.png)

Closes #54 