### PR TITLE
Prepare release 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             python3 -m pip install galaxy-language-server==${{ steps.get_version.outputs.version-without-v }}
             ```
 
-            The Galaxy Tools Extension is available at [Open VSX Registry](https://open-vsx.org/extension/davelopez/galaxy-tools) and [Visual Studio Marketplace](https://marketplace.visualstudio.com/).
+            The Galaxy Tools Extension is available at [Open VSX Registry](https://open-vsx.org/extension/davelopez/galaxy-tools) and [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=davelopez.galaxy-tools).
             You can also install the extension manually by downloading the VSIX package and using:
             ```
             code --install-extension galaxy-tools-${{ steps.get_version.outputs.version-without-v }}.vsix

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Galaxy Tools (VS Code Extension) Changelog
 
-## Unreleased
+## [0.2.0] - 2020-11-13
 
 ### Added
 
-- Settings to control completion features.
+- Settings to control completion features ([#56](https://github.com/galaxyproject/galaxy-language-server/pull/56)).
+- Auto indent on new line ([#52](https://github.com/galaxyproject/galaxy-language-server/pull/52))
+
+### Changed
+
+- Updated Galaxy Language Server [v0.2.0](./server/CHANGELOG.md#020)
 
 ## [0.1.2] - 2020-10-25
 
@@ -15,7 +20,7 @@
 
 ### Fixed
 
-- Fix error preventing the language server to start or install in Unix systems (#48).
+- Fix error preventing the language server to start or install in Unix systems ([#49](https://github.com/galaxyproject/galaxy-language-server/pull/49)).
 
 ## [0.1.1] - 2020-10-24 [YANKED]
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,18 +1,18 @@
 {
   "name": "galaxy-tools",
   "displayName": "Galaxy Tools",
-  "description": "Galaxy Tools for Visual Studio Code (unofficial) - provides XML completion, lints, snippets and other smart features to develop Galaxy (https://galaxyproject.org/) tool wrappers.",
+  "description": "Galaxy Tools for Visual Studio Code - provides XML completion, lints, snippets and other smart features to develop Galaxy (https://galaxyproject.org/) tool wrappers.",
   "author": "davelopez",
   "publisher": "davelopez",
   "license": "Apache-2.0",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "preview": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/davelopez/galaxy-language-server"
+    "url": "https://github.com/galaxyproject/galaxy-language-server"
   },
   "bugs": {
-    "url": "https://github.com/davelopez/galaxy-language-server/issues"
+    "url": "https://github.com/galaxyproject/galaxy-language-server/issues"
   },
   "categories": [
     "Programming Languages",

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,15 +1,14 @@
 # Galaxy Language Server Changelog
 
-## Unreleased
+## [0.2.0] - 2020-11-13
 
 ### Added
 
-- Client settings loading on initialization.
-- Using settings to control completion features.
+- Client settings to control completion features ([#56](https://github.com/galaxyproject/galaxy-language-server/pull/56)).
 
 ### Changed
 
-- The XML parser has been replaced for a better implementation.
+- The XML parser has been replaced with a better implementation ([#55](https://github.com/galaxyproject/galaxy-language-server/pull/55)).
 
 ## [0.1.2] - 2020-10-25
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
 pygls==0.9.1
 lxml==4.6.1
 anytree==2.8.0
-galaxy-tool-util==20.9.0
+galaxy-tool-util==20.9.1


### PR DESCRIPTION
This PR adds some small changes in preparation for the release:
- Updated changelogs.
- Updated the extension's manifest to reference the new repository URL.
- Fixed link in release template.
- Updated dependency `galaxy-tool-util` to 20.9.1