### PR TITLE
Fix xsd documentation hover

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
                 "--tcp"
             ],
             "justMyCode": false,
-            "pythonPath": "${command:python.interpreterPath}",
+            "python": "${command:python.interpreterPath}",
             "cwd": "${workspaceFolder}/server",
             "env": {
                 "PYTHONPATH": "${workspaceFolder}"

--- a/server/galaxyls/services/xsd/parser.py
+++ b/server/galaxyls/services/xsd/parser.py
@@ -43,7 +43,7 @@ class GalaxyToolXsdParser:
         self._named_type_map: Dict[str, etree._Element] = {}
         self._named_group_map: Dict[str, etree._Element] = {}
 
-    def get_tree(self) -> XsdTree:
+    def get_tree(self) -> Optional[XsdTree]:
         """Builds the tree structure from the root etree._Element if
         it does not exists, or returns it if exists.
 
@@ -93,7 +93,7 @@ class GalaxyToolXsdParser:
                 node = XsdNode(element_name, element, parent_node)
                 if not parent_node:  # Is root element
                     self._tree = XsdTree(node)
-                node.type_name = element_type_name
+                node.xsd_type = self._named_type_map.get(element_type_name)
                 self._apply_named_type_to_node(element_type_name, node, depth + 1)
                 # minOccurs defaults to 1
                 node.min_occurs = int(element.attrib.get("minOccurs", 1))

--- a/server/galaxyls/services/xsd/types.py
+++ b/server/galaxyls/services/xsd/types.py
@@ -15,10 +15,10 @@ class XsdBase:
     XML nodes and attributes.
     """
 
-    def __init__(self, name: str, element: etree.Element):
+    def __init__(self, name: str, element: Optional[etree._Element]):
         super(XsdBase, self).__init__()
         self.name: str = name
-        self.xsd_element = element
+        self.xsd_element: Optional[etree._Element] = element
 
     def __repr__(self) -> str:
         return self.name
@@ -40,7 +40,9 @@ class XsdBase:
         """
         try:
             doc = self.xsd_element.xpath(
-                "./xs:annotation/xs:documentation[@xml:lang=$lang]/text()", namespaces=self.xsd_element.nsmap, lang=lang,
+                "./xs:annotation/xs:documentation[@xml:lang=$lang]/text()",
+                namespaces=self.xsd_element.nsmap,
+                lang=lang,
             )
             return MarkupContent(MarkupKind.Markdown, doc[0].strip())
         except BaseException:
@@ -58,10 +60,14 @@ class XsdAttribute(XsdBase):
     """
 
     def __init__(
-        self, name: str, element: etree.Element, type_name: Optional[str] = None, is_required: bool = False,
+        self,
+        name: str,
+        element: Optional[etree._Element],
+        type_name: Optional[str] = None,
+        is_required: bool = False,
     ):
         super(XsdAttribute, self).__init__(name, element)
-        self.type_name: str = type_name
+        self.type_name: Optional[str] = type_name
         self.is_required: bool = is_required
         self.enumeration: List[str] = []
 
@@ -77,9 +83,9 @@ class XsdNode(XsdBase, NodeMixin):
         NodeMixin: Inherits tree node functionality from NodeMixin.
     """
 
-    def __init__(self, name: str, element: etree.Element, parent: NodeMixin = None):
+    def __init__(self, name: str, element: Optional[etree._Element], parent: Optional[NodeMixin] = None):
         super(XsdNode, self).__init__(name, element)
-        self.parent: NodeMixin = parent
+        self.parent: Optional[NodeMixin] = parent
         self.attributes: Dict[str, XsdAttribute] = {}
         self.min_occurs: int = 1  # required by default
         self.max_occurs: int = -1  # unbounded by default

--- a/server/galaxyls/tests/unit/test_xsd_service.py
+++ b/server/galaxyls/tests/unit/test_xsd_service.py
@@ -1,21 +1,54 @@
-from ...services.xsd.types import XsdNode, XsdTree
 from pytest_mock import MockerFixture
-from ...services.context import XmlContext
-from ...services.xml.nodes import XmlAttributeKey, XmlElement
+
 from ...services.xsd.constants import MSG_NO_DOCUMENTATION_AVAILABLE
 from ...services.xsd.service import GalaxyToolXsdService
 
 
 class TestGalaxyToolXsdServiceClass:
     def test_get_documentation_for_unknown_node_attribute_returns_no_documentation(self, mocker: MockerFixture) -> None:
-        fake_xsd_root = XsdNode("tool", mocker.Mock())
-        fake_xsd_tree = XsdTree(fake_xsd_root)
-        fake_element = XmlElement()
-        fake_element.name = "tool"
-        fake_node = XmlAttributeKey("uknownAttr", 0, 10, fake_element)
-        fake_context = XmlContext(fake_xsd_tree.root, fake_node)
         service = GalaxyToolXsdService("Test")
+        fake_context = mocker.Mock()
+        fake_context.is_tag = True
+        fake_context.is_attribute_key = False
+        fake_context.stack = ["unknown"]
 
         doc = service.get_documentation_for(fake_context)
 
         assert doc.value == MSG_NO_DOCUMENTATION_AVAILABLE
+
+    def test_get_documentation_for_annotated_element(self, mocker: MockerFixture) -> None:
+        service = GalaxyToolXsdService("Test")
+        fake_context = mocker.Mock()
+        fake_context.is_tag = True
+        fake_context.is_attribute_key = False
+        fake_context.stack = ["tool"]
+
+        doc = service.get_documentation_for(fake_context)
+
+        assert doc.value
+        assert doc.value != MSG_NO_DOCUMENTATION_AVAILABLE
+
+    def test_get_documentation_for_element_using_annotated_type(self, mocker: MockerFixture) -> None:
+        service = GalaxyToolXsdService("Test")
+        fake_context = mocker.Mock()
+        fake_context.is_tag = True
+        fake_context.is_attribute_key = False
+        fake_context.stack = ["tool", "macros"]
+
+        doc = service.get_documentation_for(fake_context)
+
+        assert doc.value
+        assert doc.value != MSG_NO_DOCUMENTATION_AVAILABLE
+
+    def test_get_documentation_for_annotated_attribute(self, mocker: MockerFixture) -> None:
+        service = GalaxyToolXsdService("Test")
+        fake_context = mocker.Mock()
+        fake_context.is_tag = False
+        fake_context.is_attribute_key = True
+        fake_context.token.name = "id"
+        fake_context.stack = ["tool"]
+
+        doc = service.get_documentation_for(fake_context)
+
+        assert doc.value
+        assert doc.value != MSG_NO_DOCUMENTATION_AVAILABLE


### PR DESCRIPTION
This PR fixes #63 by retrieving the documentation annotation from the XSD type definition when there is no direct annotation on the element itself. Now, most of the elements should show the correct documentation on hover.

Some of the type hints were consolidated across the related files.

Also, a couple of tests for this fix were added.
