### PR TITLE
Fix incorrect scanner state after comment

### DIFF
--- a/server/galaxyls/services/xml/scanner.py
+++ b/server/galaxyls/services/xml/scanner.py
@@ -85,6 +85,7 @@ class XmlScanner:
 
         if self.state == ScannerState.WithinComment:
             if self.stream.advance_if_chars(COMMENT_END_CHAR_SEQ):
+                self.state = ScannerState.WithinContent
                 return self._finish_token(offset, TokenType.EndCommentTag)
             self.stream.advance_until_chars(COMMENT_END_CHAR_SEQ)
             return self._finish_token(offset, TokenType.Comment)

--- a/server/galaxyls/tests/unit/test_context.py
+++ b/server/galaxyls/tests/unit/test_context.py
@@ -107,6 +107,14 @@ class TestXmlContextServiceClass:
             ('<root attr="4">\n    <^ \n<child', None, NodeType.ELEMENT, "root", ["root"]),
             ('<root attr="4">\n    < \n<^child', "child", NodeType.ELEMENT, "child", ["root", "child"]),
             ("<root><child></child>^", "root", NodeType.ELEMENT, "root", ["root"]),
+            ("<root><child><!--^Comment sample--></child>", None, NodeType.COMMENT, "child", ["root", "child"]),
+            (
+                "<root><child><!--Comment--></child><child><!--^Second comment--></child>",
+                None,
+                NodeType.COMMENT,
+                "child",
+                ["root", "child"],
+            ),
         ],
     )
     def test_get_xml_context_returns_context_with_expected_node(


### PR DESCRIPTION
The state of the scanner was not being properly updated when an XML comment was found. This was breaking the parser when there was more than one XML comment in the file.

This should fix #69