### PR TITLE
Avoid processing unknown XML documents

### DIFF
--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -151,6 +151,7 @@ def did_close(server: GalaxyToolsLanguageServer, params: DidCloseTextDocumentPar
 async def cmd_generate_test(
     server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier
 ) -> Optional[GeneratedTestResult]:
+    """Generates some test snippets based on the inputs and outputs of the document."""
     document = server.workspace.get_document(params.uri)
     return server.service.generate_test(document)
 
@@ -171,5 +172,5 @@ def _get_xml_document(document: Document) -> XmlDocument:
 
 
 def _is_document_supported(document: Document) -> bool:
-    """Returns True if the given document is not supported by the server."""
+    """Returns True if the given document is supported by the server."""
     return XmlDocument.has_valid_root(document)

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -92,9 +92,9 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
     if server.configuration.completion_mode == CompletionMode.DISABLED:
         return None
     document = server.workspace.get_document(params.textDocument.uri)
-    xml_document = _get_xml_document(document)
-    if xml_document.is_unknown:
+    if not _is_document_supported(document):
         return None
+    xml_document = _get_xml_document(document)
     return server.service.get_completion(xml_document, params, server.configuration.completion_mode)
 
 
@@ -103,9 +103,9 @@ def auto_close_tag(server: GalaxyToolsLanguageServer, params: TextDocumentPositi
     """Responds to a close tag request to close the currently opened node."""
     if server.configuration.auto_close_tags:
         document = server.workspace.get_document(params.textDocument.uri)
-        xml_document = _get_xml_document(document)
-        if xml_document.is_unknown:
+        if not _is_document_supported(document):
             return None
+        xml_document = _get_xml_document(document)
         return server.service.get_auto_close_tag(xml_document, params)
 
 
@@ -113,16 +113,18 @@ def auto_close_tag(server: GalaxyToolsLanguageServer, params: TextDocumentPositi
 def hover(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[Hover]:
     """Displays Markdown documentation for the element under the cursor."""
     document = server.workspace.get_document(params.textDocument.uri)
-    xml_document = _get_xml_document(document)
-    if xml_document.is_unknown:
+    if not _is_document_supported(document):
         return None
+    xml_document = _get_xml_document(document)
     return server.service.get_documentation(xml_document, params.position)
 
 
 @language_server.feature(FORMATTING)
-def formatting(server: GalaxyToolsLanguageServer, params: DocumentFormattingParams) -> List[TextEdit]:
+def formatting(server: GalaxyToolsLanguageServer, params: DocumentFormattingParams) -> Optional[List[TextEdit]]:
     """Formats the whole document using the provided parameters"""
     document = server.workspace.get_document(params.textDocument.uri)
+    if not _is_document_supported(document):
+        return None
     content = document.source
     return server.service.format_document(content, params)
 
@@ -156,14 +158,18 @@ async def cmd_generate_test(
 def _validate(server: GalaxyToolsLanguageServer, params) -> None:
     """Validates the Galaxy tool and reports any problem found."""
     document = server.workspace.get_document(params.textDocument.uri)
-    xml_document = _get_xml_document(document)
-    if xml_document.is_unknown:
-        return None
-    diagnostics = server.service.get_diagnostics(xml_document)
-    server.publish_diagnostics(document.uri, diagnostics)
+    if _is_document_supported(document):
+        xml_document = _get_xml_document(document)
+        diagnostics = server.service.get_diagnostics(xml_document)
+        server.publish_diagnostics(document.uri, diagnostics)
 
 
 def _get_xml_document(document: Document) -> XmlDocument:
     """Parses the input Document and returns an XmlDocument."""
     xml_document = XmlDocumentParser().parse(document)
     return xml_document
+
+
+def _is_document_supported(document: Document) -> bool:
+    """Returns True if the given document is not supported by the server."""
+    return XmlDocument.has_valid_root(document)

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -31,10 +31,13 @@ from pygls.types import (
     TextDocumentPositionParams,
     TextEdit,
 )
+from pygls.workspace import Document
 
 from .config import CompletionMode, GalaxyToolsConfiguration
 from .features import AUTO_CLOSE_TAGS, CMD_GENERATE_TEST
 from .services.language import GalaxyToolLanguageService
+from .services.xml.document import XmlDocument
+from .services.xml.parser import XmlDocumentParser
 from .types import AutoCloseTagResult, GeneratedTestResult
 
 SERVER_NAME = "Galaxy Tools LS"
@@ -89,7 +92,8 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
     if server.configuration.completion_mode == CompletionMode.DISABLED:
         return None
     document = server.workspace.get_document(params.textDocument.uri)
-    return server.service.get_completion(document, params, server.configuration.completion_mode)
+    xml_document = _get_xml_document(document)
+    return server.service.get_completion(xml_document, params, server.configuration.completion_mode)
 
 
 @language_server.feature(AUTO_CLOSE_TAGS)
@@ -97,14 +101,16 @@ def auto_close_tag(server: GalaxyToolsLanguageServer, params: TextDocumentPositi
     """Responds to a close tag request to close the currently opened node."""
     if server.configuration.auto_close_tags:
         document = server.workspace.get_document(params.textDocument.uri)
-        return server.service.get_auto_close_tag(document, params)
+        xml_document = _get_xml_document(document)
+        return server.service.get_auto_close_tag(xml_document, params)
 
 
 @language_server.feature(HOVER)
 def hover(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[Hover]:
     """Displays Markdown documentation for the element under the cursor."""
     document = server.workspace.get_document(params.textDocument.uri)
-    return server.service.get_documentation(document, params.position)
+    xml_document = _get_xml_document(document)
+    return server.service.get_documentation(xml_document, params.position)
 
 
 @language_server.feature(FORMATTING)
@@ -146,3 +152,9 @@ def _validate(server: GalaxyToolsLanguageServer, params) -> None:
     document = server.workspace.get_document(params.textDocument.uri)
     diagnostics = server.service.get_diagnostics(document)
     server.publish_diagnostics(document.uri, diagnostics)
+
+
+def _get_xml_document(document: Document) -> XmlDocument:
+    """Parses the input Document and returns an XmlDocument."""
+    xml_document = XmlDocumentParser().parse(document)
+    return xml_document

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -93,6 +93,8 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
         return None
     document = server.workspace.get_document(params.textDocument.uri)
     xml_document = _get_xml_document(document)
+    if xml_document.is_unknown:
+        return None
     return server.service.get_completion(xml_document, params, server.configuration.completion_mode)
 
 
@@ -102,6 +104,8 @@ def auto_close_tag(server: GalaxyToolsLanguageServer, params: TextDocumentPositi
     if server.configuration.auto_close_tags:
         document = server.workspace.get_document(params.textDocument.uri)
         xml_document = _get_xml_document(document)
+        if xml_document.is_unknown:
+            return None
         return server.service.get_auto_close_tag(xml_document, params)
 
 
@@ -110,6 +114,8 @@ def hover(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams)
     """Displays Markdown documentation for the element under the cursor."""
     document = server.workspace.get_document(params.textDocument.uri)
     xml_document = _get_xml_document(document)
+    if xml_document.is_unknown:
+        return None
     return server.service.get_documentation(xml_document, params.position)
 
 
@@ -150,7 +156,10 @@ async def cmd_generate_test(
 def _validate(server: GalaxyToolsLanguageServer, params) -> None:
     """Validates the Galaxy tool and reports any problem found."""
     document = server.workspace.get_document(params.textDocument.uri)
-    diagnostics = server.service.get_diagnostics(document)
+    xml_document = _get_xml_document(document)
+    if xml_document.is_unknown:
+        return None
+    diagnostics = server.service.get_diagnostics(xml_document)
     server.publish_diagnostics(document.uri, diagnostics)
 
 

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -36,11 +36,11 @@ class GalaxyToolLanguageService:
         self.completion_service = XmlCompletionService(tree)
         self.xml_context_service = XmlContextService(tree)
 
-    def get_diagnostics(self, document: Document) -> List[Diagnostic]:
-        """Validates the Galaxy tool and returns a list
+    def get_diagnostics(self, xml_document: XmlDocument) -> List[Diagnostic]:
+        """Validates the Galaxy tool XML document and returns a list
         of diagnotics if there are any problems.
         """
-        return self.xsd_service.validate_document(document)
+        return self.xsd_service.validate_document(xml_document)
 
     def get_documentation(self, xml_document: XmlDocument, position: Position) -> Optional[Hover]:
         """Gets the documentation about the element at the given position."""

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -66,6 +66,11 @@ class XmlDocument(XmlSyntaxNode):
             return self.supported_document_types.get(self.root.name, DocumentType.UNKNOWN)
         return DocumentType.UNKNOWN
 
+    @property
+    def is_macros_file(self) -> bool:
+        """Indicates if the document is a macro definition file."""
+        return self.document_type == DocumentType.MACROS
+
     def get_node_at(self, offset: int) -> Optional[XmlSyntaxNode]:
         """Gets the syntax node a the given offset."""
         return self.root.find_node_at(offset)

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional
-from anytree.search import findall
 
+from anytree.search import findall
+from lxml import etree
 from pygls.types import Position, Range
 from pygls.workspace import Document
 
@@ -117,3 +118,17 @@ class XmlDocument(XmlSyntaxNode):
         if element.is_self_closed:
             return convert_document_offset_to_position(self.document, element.end)
         return convert_document_offset_to_position(self.document, element.end_tag_close_offset)
+
+    @staticmethod
+    def has_valid_root(document: Document) -> bool:
+        """Checks if the document's root element matches one of the supported types."""
+        try:
+            xml = etree.parse(str(document.path))
+            root = xml.getroot()
+            if root and root.tag:
+                root_tag = root.tag.upper()
+                supported = [e.name for e in DocumentType if e != DocumentType.UNKNOWN]
+                return root_tag in supported
+            return False
+        except BaseException:
+            return False

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -67,6 +67,11 @@ class XmlDocument(XmlSyntaxNode):
         return DocumentType.UNKNOWN
 
     @property
+    def is_unknown(self) -> bool:
+        """Indicates if the document is of unknown type."""
+        return self.document_type == DocumentType.UNKNOWN
+
+    @property
     def is_macros_file(self) -> bool:
         """Indicates if the document is a macro definition file."""
         return self.document_type == DocumentType.MACROS

--- a/server/galaxyls/services/xml/nodes.py
+++ b/server/galaxyls/services/xml/nodes.py
@@ -2,7 +2,6 @@ from abc import ABC
 from typing import Dict, List, Optional, Tuple, cast
 
 from anytree import NodeMixin
-from anytree.search import findall
 
 from .constants import UNDEFINED_OFFSET
 from .types import NodeType

--- a/server/galaxyls/services/xsd/service.py
+++ b/server/galaxyls/services/xsd/service.py
@@ -3,15 +3,15 @@ information from the XSD schema.
 """
 
 from typing import List
-from lxml import etree
 
-from pygls.workspace import Document
+from lxml import etree
 from pygls.types import Diagnostic, MarkupContent, MarkupKind
 
-from .constants import TOOL_XSD_FILE, MSG_NO_DOCUMENTATION_AVAILABLE
+from ..context import XmlContext
+from ..xml.document import XmlDocument
+from .constants import MSG_NO_DOCUMENTATION_AVAILABLE, TOOL_XSD_FILE
 from .parser import GalaxyToolXsdParser
 from .validation import GalaxyToolValidationService
-from ..context import XmlContext
 
 NO_DOC_MARKUP = MarkupContent(MarkupKind.Markdown, MSG_NO_DOCUMENTATION_AVAILABLE)
 
@@ -31,11 +31,11 @@ class GalaxyToolXsdService:
         self.xsd_parser = GalaxyToolXsdParser(self.xsd_doc.getroot())
         self.validator = GalaxyToolValidationService(server_name, self.xsd_schema)
 
-    def validate_document(self, document: Document) -> List[Diagnostic]:
+    def validate_document(self, xml_document: XmlDocument) -> List[Diagnostic]:
         """Validates the Galaxy tool xml using the XSD schema and returns a list
         of diagnotics if there are any problems.
         """
-        return self.validator.validate_document(document)
+        return self.validator.validate_document(xml_document)
 
     def get_documentation_for(self, context: XmlContext) -> MarkupContent:
         """Gets the documentation annotated in the XSD about the

--- a/server/galaxyls/tests/unit/test_context.py
+++ b/server/galaxyls/tests/unit/test_context.py
@@ -78,7 +78,7 @@ class TestXmlContextServiceClass:
         xsd_tree_mock = mocker.Mock()
         service = XmlContextService(xsd_tree_mock)
 
-        context = service.get_xml_context(TestUtils.to_document(empty_xml_content), position)
+        context = service.get_xml_context(TestUtils.to_xml_document(empty_xml_content), position)
 
         assert context.is_empty
 
@@ -128,12 +128,12 @@ class TestXmlContextServiceClass:
     ) -> None:
         service = XmlContextService(fake_xsd_tree)
         position, source = TestUtils.extract_mark_from_source("^", source_with_mark)
-        document = TestUtils.to_document(source)
+        xml_document = TestUtils.to_xml_document(source)
         print(fake_xsd_tree.render())
         print(f"Test context at position [line={position.line}, char={position.character}]")
-        print(f"Document:\n{document.source}")
+        print(f"Document:\n{xml_document.document.source}")
 
-        context = service.get_xml_context(document, position)
+        context = service.get_xml_context(xml_document, position)
 
         assert context
         assert context.token

--- a/server/galaxyls/tests/unit/test_context.py
+++ b/server/galaxyls/tests/unit/test_context.py
@@ -78,7 +78,7 @@ class TestXmlContextServiceClass:
         xsd_tree_mock = mocker.Mock()
         service = XmlContextService(xsd_tree_mock)
 
-        context = service.get_xml_context(TestUtils.to_xml_document(empty_xml_content), position)
+        context = service.get_xml_context(TestUtils.from_source_to_xml_document(empty_xml_content), position)
 
         assert context.is_empty
 
@@ -128,7 +128,7 @@ class TestXmlContextServiceClass:
     ) -> None:
         service = XmlContextService(fake_xsd_tree)
         position, source = TestUtils.extract_mark_from_source("^", source_with_mark)
-        xml_document = TestUtils.to_xml_document(source)
+        xml_document = TestUtils.from_source_to_xml_document(source)
         print(fake_xsd_tree.render())
         print(f"Test context at position [line={position.line}, char={position.character}]")
         print(f"Document:\n{xml_document.document.source}")

--- a/server/galaxyls/tests/unit/test_validation.py
+++ b/server/galaxyls/tests/unit/test_validation.py
@@ -1,16 +1,16 @@
 import pytest
-
 from lxml import etree
+
 from ...services.xsd.constants import TOOL_XSD_FILE
 from ...services.xsd.validation import GalaxyToolValidationService
 from .sample_data import (
-    TEST_TOOL_01_DOCUMENT,
-    TEST_MACRO_01_DOCUMENT,
     TEST_INVALID_TOOL_01_DOCUMENT,
-    TEST_SYNTAX_ERROR_TOOL_01_DOCUMENT,
+    TEST_MACRO_01_DOCUMENT,
     TEST_SYNTAX_ERROR_MACRO_01_DOCUMENT,
+    TEST_SYNTAX_ERROR_TOOL_01_DOCUMENT,
+    TEST_TOOL_01_DOCUMENT,
 )
-
+from .utils import TestUtils
 
 TEST_SERVER_NAME = "Test Server"
 
@@ -25,35 +25,40 @@ def xsd_schema() -> etree.XMLSchema:
 class TestGalaxyToolValidationServiceClass:
     def test_validate_document_returns_empty_diagnostics_when_valid(self, xsd_schema: etree.XMLSchema) -> None:
         service = GalaxyToolValidationService(TEST_SERVER_NAME, xsd_schema)
+        xml_document = TestUtils.from_document_to_xml_document(TEST_TOOL_01_DOCUMENT)
 
-        actual = service.validate_document(TEST_TOOL_01_DOCUMENT)
+        actual = service.validate_document(xml_document)
 
         assert actual == []
 
     def test_validate_macro_file_returns_empty_diagnostics_when_valid(self, xsd_schema: etree.XMLSchema) -> None:
         service = GalaxyToolValidationService(TEST_SERVER_NAME, xsd_schema)
+        xml_document = TestUtils.from_document_to_xml_document(TEST_MACRO_01_DOCUMENT)
 
-        actual = service.validate_document(TEST_MACRO_01_DOCUMENT)
+        actual = service.validate_document(xml_document)
 
         assert actual == []
 
     def test_validate_document_returns_diagnostics_when_invalid(self, xsd_schema: etree.XMLSchema) -> None:
         service = GalaxyToolValidationService(TEST_SERVER_NAME, xsd_schema)
+        xml_document = TestUtils.from_document_to_xml_document(TEST_INVALID_TOOL_01_DOCUMENT)
 
-        actual = service.validate_document(TEST_INVALID_TOOL_01_DOCUMENT)
+        actual = service.validate_document(xml_document)
 
         assert len(actual) > 0
 
     def test_validate_document_returns_diagnostics_when_syntax_error(self, xsd_schema: etree.XMLSchema) -> None:
         service = GalaxyToolValidationService(TEST_SERVER_NAME, xsd_schema)
+        xml_document = TestUtils.from_document_to_xml_document(TEST_SYNTAX_ERROR_TOOL_01_DOCUMENT)
 
-        actual = service.validate_document(TEST_SYNTAX_ERROR_TOOL_01_DOCUMENT)
+        actual = service.validate_document(xml_document)
 
         assert len(actual) == 1
 
     def test_validate_macro_file_returns_diagnostics_when_syntax_error(self, xsd_schema: etree.XMLSchema) -> None:
         service = GalaxyToolValidationService(TEST_SERVER_NAME, xsd_schema)
+        xml_document = TestUtils.from_document_to_xml_document(TEST_SYNTAX_ERROR_MACRO_01_DOCUMENT)
 
-        actual = service.validate_document(TEST_SYNTAX_ERROR_MACRO_01_DOCUMENT)
+        actual = service.validate_document(xml_document)
 
         assert len(actual) == 1

--- a/server/galaxyls/tests/unit/utils.py
+++ b/server/galaxyls/tests/unit/utils.py
@@ -1,9 +1,12 @@
-from typing import Tuple
 from pathlib import Path
+from typing import Tuple
+
 from pygls.types import Position
 from pygls.workspace import Document
 
 from ...services.xml.constants import NEW_LINE
+from ...services.xml.document import XmlDocument
+from ...services.xml.parser import XmlDocumentParser
 
 
 class TestUtils:
@@ -20,6 +23,22 @@ class TestUtils:
             Document: The resulting Document.
         """
         return Document(uri, source, version)
+
+    @staticmethod
+    def to_xml_document(source: str, uri: str = "file://fake_doc.xml", version: int = 0) -> XmlDocument:
+        """Converts the given string into a parsed XML document.
+
+        Args:
+            - source (str): The input string to be converted to XmlDocument.
+            - uri (str, optional): The uri of the document. Defaults to "file://fake_doc.xml".
+            - version (int, optional): The version of the document. Defaults to 0.
+
+        Returns:
+            XmlDocument: The resulting XML document.
+        """
+        document = Document(uri, source, version)
+        xml_document = XmlDocumentParser().parse(document)
+        return xml_document
 
     @staticmethod
     def extract_mark_from_source(mark: str, source_with_mark: str) -> Tuple[Position, str]:

--- a/server/galaxyls/tests/unit/utils.py
+++ b/server/galaxyls/tests/unit/utils.py
@@ -25,7 +25,7 @@ class TestUtils:
         return Document(uri, source, version)
 
     @staticmethod
-    def to_xml_document(source: str, uri: str = "file://fake_doc.xml", version: int = 0) -> XmlDocument:
+    def from_source_to_xml_document(source: str, uri: str = "file://fake_doc.xml", version: int = 0) -> XmlDocument:
         """Converts the given string into a parsed XML document.
 
         Args:
@@ -37,6 +37,18 @@ class TestUtils:
             XmlDocument: The resulting XML document.
         """
         document = Document(uri, source, version)
+        return TestUtils.from_document_to_xml_document(document)
+
+    @staticmethod
+    def from_document_to_xml_document(document: Document) -> XmlDocument:
+        """Converts the given document into a parsed XML document.
+
+        Args:
+            - document (Document): The input string to be converted to XmlDocument.
+
+        Returns:
+            XmlDocument: The resulting XML document.
+        """
         xml_document = XmlDocumentParser().parse(document)
         return xml_document
 

--- a/server/galaxyls/tests/unit/xml/test_parser.py
+++ b/server/galaxyls/tests/unit/xml/test_parser.py
@@ -214,3 +214,58 @@ class TestXmlDocumentParserClass:
         actual = xml_document.get_node_at(offset)
 
         assert actual.node_type == expected
+
+    @pytest.mark.parametrize(
+        "source, expected",
+        [
+            ("", True),
+            (" ", True),
+            ("\n", True),
+            (" \n ", True),
+            (" \n text", True),
+            ('<?xml version="1.0" encoding="UTF-8"?>', True),
+            ("<", True),
+            ("<tool", False),
+            ("<macros", False),
+            ("<tool ", False),
+            ("<macros ", False),
+            ("<tool>", False),
+            ("<macros>", False),
+            ('<?xml version="1.0" encoding="UTF-8"?><tool>', False),
+            ('<?xml version="1.0" encoding="UTF-8"?><macros>', False),
+        ],
+    )
+    def test_parse_document_returns_expected_is_unknown(self, source: str, expected: bool) -> None:
+        parser = XmlDocumentParser()
+        document = TestUtils.to_document(source)
+        xml_document = parser.parse(document)
+
+        assert xml_document.is_unknown == expected
+
+    @pytest.mark.parametrize(
+        "source, expected",
+        [
+            ("", False),
+            (" ", False),
+            ("\n", False),
+            (" \n ", False),
+            (" \n text", False),
+            ('<?xml version="1.0" encoding="UTF-8"?>', False),
+            ("<", False),
+            ("<tool", False),
+            ("<macro", False),
+            ("<macros", True),
+            ("<tool ", False),
+            ("<macros ", True),
+            ("<tool>", False),
+            ("<macros>", True),
+            ('<?xml version="1.0" encoding="UTF-8"?><tool>', False),
+            ('<?xml version="1.0" encoding="UTF-8"?><macros>', True),
+        ],
+    )
+    def test_parse_document_returns_expected_is_macros_file(self, source: str, expected: bool) -> None:
+        parser = XmlDocumentParser()
+        document = TestUtils.to_document(source)
+        xml_document = parser.parse(document)
+
+        assert xml_document.is_macros_file == expected

--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -8,3 +8,4 @@ pytest-mock
 flake8
 flake8-bugbear
 black
+lxml-stubs


### PR DESCRIPTION
This PR detects the type of XML document when a request is received by the server and, if the XML is not one of the supported types (`tool` and `macros` at the moment), further processing of the request is ignored. This fixes some false positives when you are working with different kinds of XML documents and the Galaxy Language Server is installed since the server will not try to validate (or use any other galaxy tool-related feature) those files.

Some refactoring was needed to simplify and unify the way XML documents are processed by some of the services. Also, additional tests were added.

This fixes #74 