### PR TITLE
Basic embedded language syntax highlighting

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -39,21 +39,21 @@
         "aliases": [
           "Galaxy Tool Wrapper"
         ],
-        "configuration": "./languages/galaxytoolxml.language-configuration.json"
+        "configuration": "./src/languages/galaxytoolxml.language-configuration.json"
       },
       {
         "id": "cheetah",
         "extensions": [
           ".tmpl"
         ],
-        "configuration": "./languages/cheetah.language-configuration.json"
+        "configuration": "./src/languages/cheetah.language-configuration.json"
       },
       {
         "id": "restructuredtext",
         "extensions": [
           ".rst"
         ],
-        "configuration": "./languages/restructuredtext.language-configuration.json"
+        "configuration": "./src/languages/restructuredtext.language-configuration.json"
       }
     ],
     "grammars": [

--- a/client/package.json
+++ b/client/package.json
@@ -59,7 +59,7 @@
     "grammars": [
       {
         "language": "galaxytool",
-        "scopeName": "galaxy.tool.xml",
+        "scopeName": "text.xml.galaxytool",
         "path": "./src/syntaxes/galaxytoolxml.tmLanguage.json",
         "embeddedLanguages": {
           "source.cheetah.embedded.xml": "cheetah",

--- a/client/package.json
+++ b/client/package.json
@@ -45,13 +45,15 @@
         "id": "cheetah",
         "extensions": [
           ".tmpl"
-        ]
+        ],
+        "configuration": "./languages/cheetah.language-configuration.json"
       },
       {
         "id": "restructuredtext",
         "extensions": [
           ".rst"
-        ]
+        ],
+        "configuration": "./languages/restructuredtext.language-configuration.json"
       }
     ],
     "grammars": [

--- a/client/package.json
+++ b/client/package.json
@@ -131,7 +131,7 @@
     },
     "snippets": [
       {
-        "language": "xml",
+        "language": "galaxytool",
         "path": "./src/snippets.json"
       }
     ]

--- a/client/package.json
+++ b/client/package.json
@@ -75,6 +75,15 @@
         "language": "restructuredtext",
         "scopeName": "text.restructuredtext",
         "path": "./src/syntaxes/restructuredtext.tmLanguage.json"
+      },
+      {
+        "path": "./src/syntaxes/token.injection.json",
+        "scopeName": "token.injection",
+        "injectTo": [
+          "text.xml.galaxytool",
+          "source.cheetah",
+          "text.restructuredtext"
+        ]
       }
     ],
     "commands": [

--- a/client/package.json
+++ b/client/package.json
@@ -26,9 +26,55 @@
     "vscode": "^1.34.0"
   },
   "activationEvents": [
-    "onLanguage:xml"
+    "onLanguage:galaxytool"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "galaxytool",
+        "firstLine": "^<tool",
+        "extensions": [
+          ".xml"
+        ],
+        "aliases": [
+          "Galaxy Tool Wrapper"
+        ],
+        "configuration": "./languages/galaxytoolxml.language-configuration.json"
+      },
+      {
+        "id": "cheetah",
+        "extensions": [
+          ".tmpl"
+        ]
+      },
+      {
+        "id": "restructuredtext",
+        "extensions": [
+          ".rst"
+        ]
+      }
+    ],
+    "grammars": [
+      {
+        "language": "galaxytool",
+        "scopeName": "galaxy.tool.xml",
+        "path": "./src/syntaxes/galaxytoolxml.tmLanguage.json",
+        "embeddedLanguages": {
+          "source.cheetah.embedded.xml": "cheetah",
+          "source.restructuredtext.embedded.xml": "restructuredtext"
+        }
+      },
+      {
+        "language": "cheetah",
+        "scopeName": "source.cheetah",
+        "path": "./src/syntaxes/cheetah.tmLanguage.json"
+      },
+      {
+        "language": "restructuredtext",
+        "scopeName": "text.restructuredtext",
+        "path": "./src/syntaxes/restructuredtext.tmLanguage.json"
+      }
+    ],
     "commands": [
       {
         "command": "galaxytools.generate.tests",

--- a/client/package.json
+++ b/client/package.json
@@ -62,8 +62,8 @@
         "scopeName": "text.xml.galaxytool",
         "path": "./src/syntaxes/galaxytoolxml.tmLanguage.json",
         "embeddedLanguages": {
-          "source.cheetah.embedded.xml": "cheetah",
-          "source.restructuredtext.embedded.xml": "restructuredtext"
+          "meta.embedded.block.cheetah": "cheetah",
+          "meta.embedded.block.restructuredtext": "restructuredtext"
         }
       },
       {

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -9,6 +9,7 @@ export const LS_VENV_NAME = "glsenv";
 export const GALAXY_LS_PACKAGE = "galaxy-language-server";
 export const GALAXY_LS = "galaxyls";
 export const GALAXY_LS_VERSION = EXTENSION_VERSION; // The Extension and Language Server versions should always match
+export const LANGUAGE_ID = "galaxytool"
 
 export const PYTHON_UNIX = "python3";
 export const PYTHON_WIN = "python.exe";

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,7 +5,7 @@ import { ExtensionContext, window, TextDocument, Position, IndentAction, Languag
 import { LanguageClient, LanguageClientOptions, ServerOptions } from "vscode-languageclient";
 import { activateTagClosing, TagCloseRequest } from './tagClosing';
 import { installLanguageServer } from './setup';
-import { GALAXY_LS } from './constants';
+import { GALAXY_LS, LANGUAGE_ID } from './constants';
 import { Commands, GeneratedCommandRequest, GeneratedTestRequest, requestInsertSnippet } from './commands';
 
 let client: LanguageClient;
@@ -36,7 +36,7 @@ export async function activate(context: ExtensionContext) {
   }
 
   // Configure auto-indentation
-  languages.setLanguageConfiguration('xml', getIndentationRules());
+  languages.setLanguageConfiguration(LANGUAGE_ID, getIndentationRules());
 
   context.subscriptions.push(client.start());
 
@@ -74,8 +74,8 @@ function getClientOptions(): LanguageClientOptions {
   return {
     // Register the server for xml documents
     documentSelector: [
-      { scheme: "file", language: "xml" },
-      { scheme: "untitled", language: "xml" },
+      { scheme: "file", language: LANGUAGE_ID },
+      { scheme: "untitled", language: LANGUAGE_ID },
     ],
     outputChannelName: "[galaxyls]",
     synchronize: {

--- a/client/src/languages/cheetah.language-configuration.json
+++ b/client/src/languages/cheetah.language-configuration.json
@@ -1,0 +1,67 @@
+{
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "##"
+    },
+    // symbols used as brackets
+    "brackets": [
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ],
+        [
+            "\"",
+            "\""
+        ],
+        [
+            "'",
+            "'"
+        ]
+    ],
+    // symbols that that can be used to surround a selection
+    "surroundingPairs": [
+        [
+            "{",
+            "}"
+        ],
+        [
+            "[",
+            "]"
+        ],
+        [
+            "(",
+            ")"
+        ],
+        [
+            "\"",
+            "\""
+        ],
+        [
+            "'",
+            "'"
+        ]
+    ]
+}

--- a/client/src/languages/galaxytoolxml.language-configuration.json
+++ b/client/src/languages/galaxytoolxml.language-configuration.json
@@ -1,0 +1,102 @@
+{
+    "comments": {
+        "blockComment": [
+            "<!--",
+            "-->"
+        ]
+    },
+    "brackets": [
+        [
+            "<!--",
+            "-->"
+        ],
+        [
+            "<",
+            ">"
+        ],
+        [
+            "{",
+            "}"
+        ],
+        [
+            "(",
+            ")"
+        ]
+    ],
+    "autoClosingPairs": [
+        {
+            "open": "{",
+            "close": "}"
+        },
+        {
+            "open": "[",
+            "close": "]"
+        },
+        {
+            "open": "(",
+            "close": ")"
+        },
+        {
+            "open": "\"",
+            "close": "\"",
+            "notIn": [
+                "string"
+            ]
+        },
+        {
+            "open": "'",
+            "close": "'",
+            "notIn": [
+                "string"
+            ]
+        },
+        {
+            "open": "<!--",
+            "close": "-->",
+            "notIn": [
+                "comment",
+                "string"
+            ]
+        },
+        {
+            "open": "<![CDATA[",
+            "close": "]]>",
+            "notIn": [
+                "comment",
+                "string"
+            ]
+        }
+    ],
+    "surroundingPairs": [
+        {
+            "open": "'",
+            "close": "'"
+        },
+        {
+            "open": "\"",
+            "close": "\""
+        },
+        {
+            "open": "{",
+            "close": "}"
+        },
+        {
+            "open": "[",
+            "close": "]"
+        },
+        {
+            "open": "(",
+            "close": ")"
+        },
+        {
+            "open": "<",
+            "close": ">"
+        }
+    ],
+    "folding": {
+        "markers": {
+            "start": "^\\s*<!--\\s*#region\\b.*-->",
+            "end": "^\\s*<!--\\s*#endregion\\b.*-->"
+        }
+    }
+}

--- a/client/src/languages/restructuredtext.language-configuration.json
+++ b/client/src/languages/restructuredtext.language-configuration.json
@@ -1,0 +1,50 @@
+{
+    "comments": {
+        "lineComment": ".."
+    },
+    "brackets": [
+        [
+            "<",
+            ">"
+        ],
+        [
+            "[",
+            "]"
+        ]
+    ],
+    "autoClosingPairs": [
+        {
+            "open": "[",
+            "close": "]"
+        },
+        {
+            "open": "<",
+            "close": ">"
+        }
+    ],
+    "surroundingPairs": [
+        [
+            "*",
+            "*"
+        ],
+        [
+            "|",
+            "|"
+        ],
+        [
+            "`",
+            "`"
+        ],
+        [
+            ":",
+            ":"
+        ],
+        [
+            "<",
+            ">"
+        ]
+    ],
+    "folding": {
+        "offSide": true
+    }
+}

--- a/client/src/syntaxes/cheetah.tmLanguage.json
+++ b/client/src/syntaxes/cheetah.tmLanguage.json
@@ -7,7 +7,6 @@
   ],
   "foldingStartMarker": "^#(block|cache|def)",
   "foldingStopMarker": "^#end (block|cache|def)",
-  "keyEquivalent": "^~c",
   "name": "Cheetah templates",
   "patterns": [
     {
@@ -229,6 +228,13 @@
       },
       "name": "string.quoted.single.cheetah"
     },
+    {
+      "match": "(str|enumerate|join|split)",
+      "name": "support.function.cheetah"
+    },
+    {
+      "match": "(in|&&)",
+      "name": "keyword.control.cheetah"
     }
   ]
 }

--- a/client/src/syntaxes/cheetah.tmLanguage.json
+++ b/client/src/syntaxes/cheetah.tmLanguage.json
@@ -213,6 +213,22 @@
         }
       },
       "name": "string.quoted.double.cheetah"
+    },
+    {
+      "begin": "'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.cheetah"
+        }
+      },
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.cheetah"
+        }
+      },
+      "name": "string.quoted.single.cheetah"
+    },
     }
   ]
 }

--- a/client/src/syntaxes/cheetah.tmLanguage.json
+++ b/client/src/syntaxes/cheetah.tmLanguage.json
@@ -1,0 +1,203 @@
+{
+  "comment": "Syntax highlighting for Cheetah templates based on https://github.com/irlabs/Cheetah.tmbundle/blob/master/Syntaxes/Cheetah%20templates.plist",
+  "scopeName": "source.cheetah",
+  "uuid": "9DD24FCA-A42A-4158-993B-FB3B05DB4736",
+  "fileTypes": [
+    "tmpl"
+  ],
+  "foldingStartMarker": "^#(block|cache|def)",
+  "foldingStopMarker": "^#end (block|cache|def)",
+  "keyEquivalent": "^~c",
+  "name": "Cheetah templates",
+  "patterns": [
+    {
+      "match": "##.*$",
+      "name": "comment.line.cheetah"
+    },
+    {
+      "begin": "#\\*",
+      "end": "\\*#",
+      "name": "comment.block.cheetah"
+    },
+    {
+      "begin": "^(#cache)",
+      "beginCaptures": {
+        "1": {
+          "name": "support.other.directive.cheetah"
+        }
+      },
+      "end": "$",
+      "name": "meta.directive.cache.cheetah",
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "variable.parameter.cheetah"
+            },
+            "2": {
+              "name": "entity.name.directive.cache.cheetah"
+            }
+          },
+          "match": "(id)='([a-zA-Z_][a-zA-Z0-9_]*)'",
+          "name": "meta.directive.cache"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "variable.parameter.cheetah"
+            }
+          },
+          "match": "(id|timer|test)=",
+          "name": "meta.directive.cache"
+        }
+      ]
+    },
+    {
+      "begin": "^(#end cache)(.*)?",
+      "beginCaptures": {
+        "1": {
+          "name": "support.other.directive.cheetah"
+        },
+        "2": {
+          "name": "entity.name.directive.cache.cheetah"
+        }
+      },
+      "end": "$",
+      "name": "meta.directive.cache.cheetah"
+    },
+    {
+      "begin": "^(#(end )?(block|def))\\s+([a-zA-Z_][a-zA-Z0-9_]*)(\\()?",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.function.cheetah"
+        },
+        "2": {
+          "name": "support.other.cheetah"
+        },
+        "4": {
+          "name": "entity.name.function.cheetah"
+        },
+        "5": {
+          "name": "punctuation.definition.parameters.begin.cheetah"
+        }
+      },
+      "end": "(\\))?$",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.parameters.end.cheetah"
+        }
+      },
+      "name": "meta.function.cheetah",
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "variable.parameter.function.cheetah"
+            }
+          },
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+          "name": "meta.function.parameters.cheetah"
+        }
+      ]
+    },
+    {
+      "match": "\\$[a-zA-Z.\\(\\)]*",
+      "name": "variable.other.cheetah"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.other.include.import.cheetah"
+        },
+        "2": {
+          "name": "keyword.other.include.as.cheetah"
+        }
+      },
+      "match": "^(#import)\\s+[a-zA-Z_][a-zA-Z0-9_]*\\s+(as)?",
+      "name": "meta.other.include.cheetah"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.other.include.from.cheetah"
+        },
+        "2": {
+          "name": "keyword.other.include.import.cheetah"
+        },
+        "3": {
+          "name": "keyword.other.include.as.cheetah"
+        }
+      },
+      "match": "^(#from)\\s+[a-zA-Z_][a-zA-Z0-9_]*\\s+(import)\\s+[a-zA-Z_][a-zA-Z0-9_]*\\s+(as)?",
+      "name": "meta.other.include.cheetah"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.other.extends.cheetah"
+        },
+        "2": {
+          "name": "entity.other.inherited-class"
+        }
+      },
+      "match": "^(#extends)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+      "name": "meta.other.extends.cheetah"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.other.implements.cheetah"
+        },
+        "2": {
+          "name": "entity.name.function.cheetah"
+        }
+      },
+      "match": "^(#implements)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+      "name": "meta.other.implements.cheetah"
+    },
+    {
+      "match": "#(end )?(for|if|repeat|try|unless|while)\\b",
+      "name": "keyword.control.cheetah"
+    },
+    {
+      "match": "#(end )?(raw)\\b",
+      "name": "keyword.other.cheetah"
+    },
+    {
+      "match": "#(else if)\\b",
+      "name": "keyword.control.cheetah"
+    },
+    {
+      "match": "#(assert|break|continue|else|elif|except|finally|pass|raise|stop)\\b",
+      "name": "keyword.control.cheetah"
+    },
+    {
+      "match": "#(attr|del|echo|filter|silent)\\b",
+      "name": "keyword.other.cheetah"
+    },
+    {
+      "match": "^#set(\\s+global)?",
+      "name": "keyword.other.cheetah"
+    },
+    {
+      "match": "#slurp",
+      "name": "keyword.directive.cheetah"
+    },
+    {
+      "match": "^#((end )?(compiler-settings)|breakpoint)\\b",
+      "name": "support.other.directive.cheetah"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "support.other.cheetah"
+        },
+        "2": {
+          "name": "support.decorator.cheetah"
+        }
+      },
+      "match": "^(#@(staticmethod|classmethod))\\b",
+      "name": "meta.function.decorator.cheetah"
+    }
+  ]
+}

--- a/client/src/syntaxes/cheetah.tmLanguage.json
+++ b/client/src/syntaxes/cheetah.tmLanguage.json
@@ -198,6 +198,21 @@
       },
       "match": "^(#@(staticmethod|classmethod))\\b",
       "name": "meta.function.decorator.cheetah"
+    },
+    {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.cheetah"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.cheetah"
+        }
+      },
+      "name": "string.quoted.double.cheetah"
     }
   ]
 }

--- a/client/src/syntaxes/cheetah.tmLanguage.json
+++ b/client/src/syntaxes/cheetah.tmLanguage.json
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "match": "\\$[a-zA-Z.\\(\\)]*",
+      "match": "\\$[a-zA-Z0-9_.]*",
       "name": "variable.other.cheetah"
     },
     {

--- a/client/src/syntaxes/cheetah.tmLanguage.json
+++ b/client/src/syntaxes/cheetah.tmLanguage.json
@@ -155,7 +155,7 @@
       "name": "meta.other.implements.cheetah"
     },
     {
-      "match": "#(end )?(for|if|repeat|try|unless|while)\\b",
+      "match": "#(end )?(for|if|repeat|try|unless|while|set)\\b",
       "name": "keyword.control.cheetah"
     },
     {
@@ -229,11 +229,11 @@
       "name": "string.quoted.single.cheetah"
     },
     {
-      "match": "(str|enumerate|join|split)",
+      "match": "\\b(str|enumerate|join|split)\\b",
       "name": "support.function.cheetah"
     },
     {
-      "match": "(in|&&)",
+      "match": "\\b(in)\\b",
       "name": "keyword.control.cheetah"
     }
   ]

--- a/client/src/syntaxes/galaxytoolxml.tmLanguage.json
+++ b/client/src/syntaxes/galaxytoolxml.tmLanguage.json
@@ -1,0 +1,418 @@
+{
+    "comment": "Custom XML grammar for Galaxy tool wrappers based on https://github.com/microsoft/vscode/blob/master/extensions/xml/syntaxes/xml.tmLanguage.json",
+    "name": "Galaxy Tool XML Wrapper",
+    "scopeName": "galaxy.tool.xml",
+    "patterns": [
+        {
+            "begin": "(<\\?)\\s*([-_a-zA-Z0-9]+)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.xml"
+                }
+            },
+            "end": "(\\?>)",
+            "name": "meta.tag.preprocessor.xml",
+            "patterns": [
+                {
+                    "match": " ([a-zA-Z-]+)",
+                    "name": "entity.other.attribute-name.xml"
+                },
+                {
+                    "include": "#doublequotedString"
+                },
+                {
+                    "include": "#singlequotedString"
+                }
+            ]
+        },
+        {
+            "begin": "(<!)(DOCTYPE)\\s+([:a-zA-Z_][:a-zA-Z0-9_.-]*)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "keyword.other.doctype.xml"
+                },
+                "3": {
+                    "name": "variable.language.documentroot.xml"
+                }
+            },
+            "end": "\\s*(>)",
+            "name": "meta.tag.sgml.doctype.xml",
+            "patterns": [
+                {
+                    "include": "#internalSubset"
+                }
+            ]
+        },
+        {
+            "include": "#comments"
+        },
+        {
+            "begin": "(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.xml"
+                },
+                "3": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "4": {
+                    "name": "punctuation.separator.namespace.xml"
+                },
+                "5": {
+                    "name": "entity.name.tag.localname.xml"
+                }
+            },
+            "end": "(>)(</)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "3": {
+                    "name": "entity.name.tag.xml"
+                },
+                "4": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "5": {
+                    "name": "punctuation.separator.namespace.xml"
+                },
+                "6": {
+                    "name": "entity.name.tag.localname.xml"
+                },
+                "7": {
+                    "name": "punctuation.definition.tag.xml"
+                }
+            },
+            "name": "meta.tag.no-content.xml",
+            "patterns": [
+                {
+                    "include": "#tagStuff"
+                }
+            ]
+        },
+        {
+            "include": "#commandSection"
+        },
+        {
+            "begin": "(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "3": {
+                    "name": "entity.name.tag.xml"
+                },
+                "4": {
+                    "name": "punctuation.separator.namespace.xml"
+                },
+                "5": {
+                    "name": "entity.name.tag.localname.xml"
+                }
+            },
+            "end": "(/?>)",
+            "name": "meta.tag.xml",
+            "patterns": [
+                {
+                    "include": "#tagStuff"
+                }
+            ]
+        },
+        {
+            "include": "#entity"
+        },
+        {
+            "include": "#bare-ampersand"
+        },
+        {
+            "begin": "<%@",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.xml"
+                }
+            },
+            "end": "%>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.xml"
+                }
+            },
+            "name": "source.java-props.embedded.xml",
+            "patterns": [
+                {
+                    "match": "page|include|taglib",
+                    "name": "keyword.other.page-props.xml"
+                }
+            ]
+        },
+        {
+            "begin": "<%[!=]?(?!--)",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.xml"
+                }
+            },
+            "end": "(?!--)%>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.xml"
+                }
+            },
+            "name": "source.java.embedded.xml",
+            "patterns": [
+                {
+                    "include": "source.java"
+                }
+            ]
+        },
+        {
+            "include": "#helpSection"
+        },
+        {
+            "begin": "<!\\[CDATA\\[",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.xml"
+                }
+            },
+            "end": "]]>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.xml"
+                }
+            },
+            "name": "string.unquoted.cdata.xml"
+        }
+    ],
+    "repository": {
+        "EntityDecl": {
+            "begin": "(<!)(ENTITY)\\s+(%\\s+)?([:a-zA-Z_][:a-zA-Z0-9_.-]*)(\\s+(?:SYSTEM|PUBLIC)\\s+)?",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "keyword.other.entity.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.entity.xml"
+                },
+                "4": {
+                    "name": "variable.language.entity.xml"
+                },
+                "5": {
+                    "name": "keyword.other.entitytype.xml"
+                }
+            },
+            "end": "(>)",
+            "patterns": [
+                {
+                    "include": "#doublequotedString"
+                },
+                {
+                    "include": "#singlequotedString"
+                }
+            ]
+        },
+        "bare-ampersand": {
+            "match": "&",
+            "name": "invalid.illegal.bad-ampersand.xml"
+        },
+        "doublequotedString": {
+            "begin": "\"",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.xml"
+                }
+            },
+            "end": "\"",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.xml"
+                }
+            },
+            "name": "string.quoted.double.xml",
+            "patterns": [
+                {
+                    "include": "#entity"
+                },
+                {
+                    "include": "#bare-ampersand"
+                }
+            ]
+        },
+        "entity": {
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.constant.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.constant.xml"
+                }
+            },
+            "match": "(&)([:a-zA-Z_][:a-zA-Z0-9_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+            "name": "constant.character.entity.xml"
+        },
+        "internalSubset": {
+            "begin": "(\\[)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.constant.xml"
+                }
+            },
+            "end": "(\\])",
+            "name": "meta.internalsubset.xml",
+            "patterns": [
+                {
+                    "include": "#EntityDecl"
+                },
+                {
+                    "include": "#parameterEntity"
+                },
+                {
+                    "include": "#comments"
+                }
+            ]
+        },
+        "parameterEntity": {
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.constant.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.constant.xml"
+                }
+            },
+            "match": "(%)([:a-zA-Z_][:a-zA-Z0-9_.-]*)(;)",
+            "name": "constant.character.parameter-entity.xml"
+        },
+        "singlequotedString": {
+            "begin": "'",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.xml"
+                }
+            },
+            "end": "'",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.xml"
+                }
+            },
+            "name": "string.quoted.single.xml",
+            "patterns": [
+                {
+                    "include": "#entity"
+                },
+                {
+                    "include": "#bare-ampersand"
+                }
+            ]
+        },
+        "tagStuff": {
+            "patterns": [
+                {
+                    "captures": {
+                        "1": {
+                            "name": "entity.other.attribute-name.namespace.xml"
+                        },
+                        "2": {
+                            "name": "entity.other.attribute-name.xml"
+                        },
+                        "3": {
+                            "name": "punctuation.separator.namespace.xml"
+                        },
+                        "4": {
+                            "name": "entity.other.attribute-name.localname.xml"
+                        }
+                    },
+                    "match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*="
+                },
+                {
+                    "include": "#doublequotedString"
+                },
+                {
+                    "include": "#singlequotedString"
+                }
+            ]
+        },
+        "comments": {
+            "patterns": [
+                {
+                    "begin": "<%--",
+                    "captures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.xml"
+                        },
+                        "end": "--%>",
+                        "name": "comment.block.xml"
+                    }
+                },
+                {
+                    "begin": "<!--",
+                    "captures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.xml"
+                        }
+                    },
+                    "end": "-->",
+                    "name": "comment.block.xml",
+                    "patterns": [
+                        {
+                            "begin": "--(?!>)",
+                            "captures": {
+                                "0": {
+                                    "name": "invalid.illegal.bad-comments-or-CDATA.xml"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "commandSection": {
+            "begin": "<command[\\w\\s\"=]*>",
+            "name": "punctuation.section.command.xml",
+            "end": "<\/command>",
+            "patterns": [
+                {
+                    "begin": "<!\\[CDATA\\[",
+                    "name": "source.cheetah.embedded.xml",
+                    "end": "]]>",
+                    "patterns": [
+                        {
+                            "include": "#tagStuff"
+                        },
+                        {
+                            "include": "source.cheetah"
+                        }
+                    ]
+                }
+            ]
+        },
+        "helpSection": {
+            "begin": "<help><!\\[CDATA\\[",
+            "name": "source.restructuredtext.embedded.xml",
+            "end": "]]>",
+            "patterns": [
+                {
+                    "include": "text.restructuredtext"
+                }
+            ]
+        }
+    }
+}

--- a/client/src/syntaxes/galaxytoolxml.tmLanguage.json
+++ b/client/src/syntaxes/galaxytoolxml.tmLanguage.json
@@ -385,14 +385,41 @@
             ]
         },
         "commandSection": {
-            "begin": "<command[\\w\\s\"=]*>",
-            "contentName": "punctuation.section.command.xml",
-            "end": "</command>",
+            "begin": "(<)(command)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.namespace.xml"
+                }
+            },
+            "name": "meta.tag.xml",
+            "end": "(</)(command)(>)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.xml"
+                }
+            },
             "patterns": [
                 {
+                    "match": ">",
+                    "name": "punctuation.definition.tag.xml"
+                },
+                {
+                    "include": "#tagStuff"
+                },
+                {
                     "begin": "<!\\[CDATA\\[",
-                    "contentName": "source.cheetah.embedded.xml",
                     "end": "]]>",
+                    "name": "string.unquoted.cdata.xml",
+                    "contentName": "meta.embedded.block.cheetah",
                     "patterns": [
                         {
                             "include": "source.cheetah"
@@ -402,14 +429,37 @@
             ]
         },
         "helpSection": {
-            "begin": "<help[\\w\\s\"=]*>",
-            "contentName": "punctuation.section.help.xml",
-            "end": "</help>",
+            "begin": "(<)(help)(>)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.xml"
+                }
+            },
+            "end": "(</)(help)(>)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.xml"
+                }
+            },
+            "name": "meta.tag.xml",
             "patterns": [
                 {
                     "begin": "<!\\[CDATA\\[",
-                    "contentName": "source.restructuredtext.embedded.xml",
                     "end": "]]>",
+                    "name": "string.unquoted.cdata.xml",
+                    "contentName": "meta.embedded.block.restructuredtext",
                     "patterns": [
                         {
                             "include": "text.restructuredtext"

--- a/client/src/syntaxes/galaxytoolxml.tmLanguage.json
+++ b/client/src/syntaxes/galaxytoolxml.tmLanguage.json
@@ -1,7 +1,7 @@
 {
     "comment": "Custom XML grammar for Galaxy tool wrappers based on https://github.com/microsoft/vscode/blob/master/extensions/xml/syntaxes/xml.tmLanguage.json",
     "name": "Galaxy Tool XML Wrapper",
-    "scopeName": "galaxy.tool.xml",
+    "scopeName": "text.xml.galaxytool",
     "patterns": [
         {
             "begin": "(<\\?)\\s*([-_a-zA-Z0-9]+)",

--- a/client/src/syntaxes/galaxytoolxml.tmLanguage.json
+++ b/client/src/syntaxes/galaxytoolxml.tmLanguage.json
@@ -106,6 +106,9 @@
             "include": "#commandSection"
         },
         {
+            "include": "#helpSection"
+        },
+        {
             "begin": "(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)",
             "captures": {
                 "1": {
@@ -178,9 +181,6 @@
                     "include": "source.java"
                 }
             ]
-        },
-        {
-            "include": "#helpSection"
         },
         {
             "begin": "<!\\[CDATA\\[",
@@ -386,17 +386,14 @@
         },
         "commandSection": {
             "begin": "<command[\\w\\s\"=]*>",
-            "name": "punctuation.section.command.xml",
-            "end": "<\/command>",
+            "contentName": "punctuation.section.command.xml",
+            "end": "</command>",
             "patterns": [
                 {
                     "begin": "<!\\[CDATA\\[",
-                    "name": "source.cheetah.embedded.xml",
+                    "contentName": "source.cheetah.embedded.xml",
                     "end": "]]>",
                     "patterns": [
-                        {
-                            "include": "#tagStuff"
-                        },
                         {
                             "include": "source.cheetah"
                         }
@@ -405,12 +402,19 @@
             ]
         },
         "helpSection": {
-            "begin": "<help><!\\[CDATA\\[",
-            "name": "source.restructuredtext.embedded.xml",
-            "end": "]]>",
+            "begin": "<help[\\w\\s\"=]*>",
+            "contentName": "punctuation.section.help.xml",
+            "end": "</help>",
             "patterns": [
                 {
-                    "include": "text.restructuredtext"
+                    "begin": "<!\\[CDATA\\[",
+                    "contentName": "source.restructuredtext.embedded.xml",
+                    "end": "]]>",
+                    "patterns": [
+                        {
+                            "include": "text.restructuredtext"
+                        }
+                    ]
                 }
             ]
         }

--- a/client/src/syntaxes/galaxytoolxml.tmLanguage.json
+++ b/client/src/syntaxes/galaxytoolxml.tmLanguage.json
@@ -106,6 +106,9 @@
             "include": "#commandSection"
         },
         {
+            "include": "#configFileSection"
+        },
+        {
             "include": "#helpSection"
         },
         {
@@ -396,6 +399,50 @@
             },
             "name": "meta.tag.xml",
             "end": "(</)(command)(>)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.xml"
+                }
+            },
+            "patterns": [
+                {
+                    "match": ">",
+                    "name": "punctuation.definition.tag.xml"
+                },
+                {
+                    "include": "#tagStuff"
+                },
+                {
+                    "begin": "<!\\[CDATA\\[",
+                    "end": "]]>",
+                    "name": "string.unquoted.cdata.xml",
+                    "contentName": "meta.embedded.block.cheetah",
+                    "patterns": [
+                        {
+                            "include": "source.cheetah"
+                        }
+                    ]
+                }
+            ]
+        },
+        "configFileSection": {
+            "begin": "(<)(configfile\\b)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.namespace.xml"
+                }
+            },
+            "name": "meta.tag.xml",
+            "end": "(</)(configfile)(>)",
             "endCaptures": {
                 "1": {
                     "name": "punctuation.definition.tag.xml"

--- a/client/src/syntaxes/restructuredtext.tmLanguage.json
+++ b/client/src/syntaxes/restructuredtext.tmLanguage.json
@@ -1,0 +1,548 @@
+{
+  "comment": "Syntax highlighting for reStructuredText: http://docutils.sourceforge.net based on https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/syntaxes/restructuredtext.tmLanguage",
+  "scopeName": "text.restructuredtext",
+  "uuid": "62DA9AD6-36E1-4AB7-BB87-E933AD9FD1A4",
+  "fileTypes": [
+    "rst",
+    "rest"
+  ],
+  "keyEquivalent": "^~R",
+  "name": "reStructuredText",
+  "patterns": [
+    {
+      "begin": "^([ \\t]*)(?=\\S)",
+      "contentName": "meta.paragraph.restructuredtext",
+      "end": "^(?!\\1)",
+      "patterns": [
+        {
+          "include": "#all"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "all": {
+      "patterns": [
+        {
+          "include": "#directives"
+        },
+        {
+          "include": "#raw-blocks"
+        },
+        {
+          "include": "#emphasis"
+        },
+        {
+          "include": "#link-def"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.substitution.restructuredtext"
+            },
+            "2": {
+              "name": "markup.underline.substitution.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.substitution.restructuredtext"
+            }
+          },
+          "comment": "substitution",
+          "match": "(\\|)([^| ]+[^|]*[^| ]*)(\\|_{0,2})"
+        },
+        {
+          "begin": "``",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.raw.restructuredtext"
+            }
+          },
+          "comment": "inline literal",
+          "end": "``((?=[^`\\w\\d])|$)",
+          "name": "markup.raw.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.intepreted.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.intepreted.restructuredtext"
+            }
+          },
+          "comment": "intepreted text - single line",
+          "match": "(`)[^`]+(`)(?!_)",
+          "name": "markup.other.command.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.link.restructuredtext"
+            },
+            "2": {
+              "name": "markup.underline.link.restructuredtext"
+            }
+          },
+          "comment": "anonymous links __ url",
+          "match": "\\s*(__)\\s+(.+)",
+          "name": "meta.link.restructuredtext"
+        },
+        {
+          "include": "#link-reference"
+        },
+        {
+          "begin": "(:)([-A-z0-9_.]*)(:)(`)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.intepreted.restructuredtext"
+            },
+            "2": {
+              "name": "entity.name.role.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.intepreted.restructuredtext"
+            },
+            "4": {
+              "name": "punctuation.definition.intepreted.restructuredtext"
+            }
+          },
+          "comment": "intepreted text - multiline with role",
+          "contentName": "string.other.interpreted.restructuredtext",
+          "end": "(`)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.intepreted.restructuredtext"
+            }
+          },
+          "name": "markup.other.command.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.link.restructuredtext"
+            },
+            "2": {
+              "name": "string.other.link.title.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.location.restructuredtext"
+            },
+            "4": {
+              "name": "markup.underline.link.restructuredtext"
+            },
+            "5": {
+              "name": "punctuation.definition.location.restructuredtext"
+            },
+            "6": {
+              "name": "punctuation.definition.link.restructuredtext"
+            }
+          },
+          "comment": "links `...`_ ",
+          "match": "(`)([^<`]+)\\s+(<)(.*?)(>)(`_)",
+          "name": "meta.link.inline.restructuredtext"
+        },
+        {
+          "include": "#footnotes"
+        },
+        {
+          "include": "#citations"
+        },
+        {
+          "include": "#tags"
+        },
+        {
+          "include": "#tables"
+        },
+        {
+          "include": "#headings"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "citations": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.link.restructuredtext"
+            },
+            "2": {
+              "name": "constant.other.citation.link.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "4": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "5": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "6": {
+              "name": "string.other.citation.restructuredtext"
+            }
+          },
+          "comment": "replacement",
+          "match": "^(\\.\\.)\\s+((\\[)[A-z][A-z0-9]*(\\]))(_)\\s+(.*)",
+          "name": "meta.link.citation.def.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "constant.other.citation.link.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "4": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            }
+          },
+          "comment": "citation reference",
+          "match": "((\\[)[A-z][A-z0-9_-]*(\\]))(_)",
+          "name": "meta.link.citation.restructuredtext"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "^(\\.\\.)[ ]",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.comment.restructuredtext"
+            }
+          },
+          "end": "^[\\s]*$\\n?",
+          "name": "comment.line.double-dot.restructuredtext"
+        }
+      ]
+    },
+    "directives": {
+      "patterns": [
+        {
+          "match": "^[ \\t]*(\\.\\.)\\s((\\|)(.*)(\\|)\\s)?([A-z][-A-z0-9_]+)(::)((\\s[Uu](\\+)\\d{4,5})?(\\s[-A-z0-9_]+([(])[-A-z0-9_]*([)]))?(\\s(\\.\\.)\\s)?.*)?",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.directive.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.substitution.restructuredtext"
+            },
+            "4": {
+              "name": "markup.underline.substitution.restructuredtext"
+            },
+            "5": {
+              "name": "punctuation.definition.substitution.restructuredtext"
+            },
+            "6": {
+              "name": "support.directive.restructuredtext"
+            },
+            "7": {
+              "name": "punctuation.separator.key-value.restructuredtext"
+            },
+            "8": {
+              "name": "entity.name.directive.restructuredtext"
+            },
+            "10": {
+              "name": "punctuation.definition.directive.restructuredtext"
+            },
+            "12": {
+              "name": "punctuation.definition.directive.restructuredtext"
+            },
+            "13": {
+              "name": "punctuation.definition.directive.restructuredtext"
+            },
+            "15": {
+              "name": "punctuation.definition.directive.restructuredtext"
+            }
+          }
+        }
+      ]
+    },
+    "emphasis": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.bold.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.bold.restructuredtext"
+            }
+          },
+          "match": "(\\*\\*)[^*]+(\\*\\*)",
+          "name": "markup.bold.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.italic.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.italic.restructuredtext"
+            }
+          },
+          "match": "(\\*)\\w[^*]+\\w(\\*)",
+          "name": "markup.italic.restructuredtext"
+        }
+      ]
+    },
+    "footnotes": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.link.restructuredtext"
+            },
+            "2": {
+              "name": "constant.other.footnote.link.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "6": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "7": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "8": {
+              "name": "string.other.footnote.restructuredtext"
+            }
+          },
+          "comment": "replacement",
+          "match": "^(\\.\\.)\\s+((\\[)(((#?)[^]]*?)|\\*)(\\]))\\s+(.*)",
+          "name": "meta.link.footnote.def.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "constant.other.footnote.link"
+            },
+            "2": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "4": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            }
+          },
+          "comment": "footnote reference: [0]_",
+          "match": "((\\[)[0-9]+(\\]))(_)",
+          "name": "meta.link.footnote.numeric.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "constant.other.footnote.link"
+            },
+            "2": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "4": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            }
+          },
+          "comment": "footnote reference [#]_ or [#foo]_",
+          "match": "((\\[#)[A-z0-9_\\-]*(\\]))(_)",
+          "name": "meta.link.footnote.auto.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "constant.other.footnote.link.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "3": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            },
+            "4": {
+              "name": "punctuation.definition.constant.restructuredtext"
+            }
+          },
+          "comment": "footnote reference [*]_",
+          "match": "((\\[)\\*(\\]))(_)",
+          "name": "meta.link.footnote.symbol.auto.restructuredtext"
+        }
+      ]
+    },
+    "headings": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.heading.restructuredtext"
+            }
+          },
+          "match": "(^\\s*(=|-|~|`|#|\"|\\^|\\+|\\*|:|\\.|'|_|\\+){3,}$){1,1}?",
+          "name": "markup.heading.restructuredtext"
+        }
+      ]
+    },
+    "link-def": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.link.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.string.restructuredtext"
+            },
+            "3": {
+              "name": "string.other.link.title.restructuredtext"
+            },
+            "4": {
+              "name": "punctuation.separator.key-value.restructuredtext"
+            },
+            "5": {
+              "name": "markup.underline.link.restructuredtext"
+            }
+          },
+          "comment": "replacement",
+          "match": "(\\.\\.)\\s+(_)([-.\\d\\w\\s()]+)(:)\\s+(.*)",
+          "name": "meta.link.reference.def.restructuredtext"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.link.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.string.restructuredtext"
+            },
+            "3": {
+              "name": "string.other.link.title.restructuredtext"
+            },
+            "4": {
+              "name": "punctuation.separator.key-value.restructuredtext"
+            },
+            "5": {
+              "name": "markup.underline.link.restructuredtext"
+            }
+          },
+          "comment": "replacement",
+          "match": "(\\.\\.)\\s+(_`)([^`]+)(`:)\\s+(.*)",
+          "name": "meta.link.reference.def.restructuredtext"
+        }
+      ]
+    },
+    "link-reference": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "string.other.link.title.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.link.restructuredtext"
+            }
+          },
+          "match": "\\b([-.:+_\\d\\w]+)(_)\\b",
+          "name": "meta.link.reference"
+        },
+        {
+          "begin": "(`)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.link.restructuredtext"
+            }
+          },
+          "end": "(`_)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.link.restructuredtext"
+            }
+          },
+          "name": "meta.link.reference",
+          "patterns": [
+            {
+              "match": "[^`]+",
+              "name": "string.other.link.title.restructuredtext"
+            }
+          ]
+        }
+      ]
+    },
+    "raw-blocks": {
+      "patterns": [
+        {
+          "begin": "(::)$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.section.raw.restructuredtext"
+            }
+          },
+          "comment": "Literal Blocks",
+          "contentName": "meta.raw.block.restructuredtext",
+          "end": "^(?=\\S)",
+          "patterns": [
+            {
+              "include": "#raw-blocks-inner"
+            }
+          ]
+        }
+      ]
+    },
+    "raw-blocks-inner": {
+      "patterns": [
+        {
+          "match": ".+",
+          "name": "markup.raw.inner.restructuredtext"
+        }
+      ]
+    },
+    "tables": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.table.restructuredtext"
+            }
+          },
+          "match": "\\+-[+-]+",
+          "name": "markup.other.table.restructuredtext"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.table.restructuredtext"
+            }
+          },
+          "match": "\\+=[+=]+",
+          "name": "markup.other.table.restructuredtext"
+        }
+      ]
+    },
+    "tags": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.field.restructuredtext"
+            },
+            "2": {
+              "name": "punctuation.definition.field.restructuredtext"
+            }
+          },
+          "comment": "tags (and field lists)",
+          "match": "(:)[[:alpha:]][[[:alpha:]]0-9  =\\s\\t_.-]*(:)",
+          "name": "entity.name.tag.restructuredtext"
+        }
+      ]
+    }
+  }
+}

--- a/client/src/syntaxes/restructuredtext.tmLanguage.json
+++ b/client/src/syntaxes/restructuredtext.tmLanguage.json
@@ -6,18 +6,10 @@
     "rst",
     "rest"
   ],
-  "keyEquivalent": "^~R",
   "name": "reStructuredText",
   "patterns": [
     {
-      "begin": "^([ \\t]*)(?=\\S)",
-      "contentName": "meta.paragraph.restructuredtext",
-      "end": "^(?!\\1)",
-      "patterns": [
-        {
-          "include": "#all"
-        }
-      ]
+      "include": "#all"
     }
   ],
   "repository": {

--- a/client/src/syntaxes/token.injection.json
+++ b/client/src/syntaxes/token.injection.json
@@ -1,0 +1,15 @@
+{
+    "scopeName": "token.injection",
+    "injectionSelector": "L:meta.tag.xml",
+    "patterns": [
+        {
+            "include": "#token"
+        }
+    ],
+    "repository": {
+        "token": {
+            "match": "@[[:upper:]_]*@",
+            "name": "variable.other.constant"
+        }
+    }
+}

--- a/client/src/syntaxes/token.injection.json
+++ b/client/src/syntaxes/token.injection.json
@@ -8,7 +8,7 @@
     ],
     "repository": {
         "token": {
-            "match": "@[[:upper:]_]*@",
+            "match": "@[[:upper:]_0-9]*@",
             "name": "variable.other.constant"
         }
     }


### PR DESCRIPTION
Instead of using the default language configuration and grammar for plain old XML files in Galaxy tool wrappers, a new `galaxytool` (any suggestions for a better name?) [language identifier](https://github.com/galaxyproject/galaxy-language-server/compare/syntax-highlight?expand=1#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fR34) has been defined along with new [grammar](https://github.com/galaxyproject/galaxy-language-server/compare/syntax-highlight?expand=1#diff-a5edc587c0e6c95988c31502d478ebdf67ba2f76ad63db3a2fa7d8786cc1ed65) and [configuration](https://github.com/galaxyproject/galaxy-language-server/compare/syntax-highlight?expand=1#diff-9de90a0c1e88d491eadcaad87d1d63a43ec9db925f8e712e09be84682596c1c2) files based on the existing one [here](https://github.com/microsoft/vscode/blob/master/extensions/xml/syntaxes/xml.tmLanguage.json) but with some customizations to support basic `Cheetah` and `reStructuredText` embedded syntax highlighting.

In addition, similar grammar and configuration files for Cheetah and reStructuredText have been also added based on the respective existing ones [here](https://github.com/irlabs/Cheetah.tmbundle/blob/master/Syntaxes/Cheetah%20templates.plist) and [here](https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/syntaxes/restructuredtext.tmLanguage).

These changes allow to better identify and tell apart `Galaxy tool wrappers` from regular XML files in VSCode:
![image](https://user-images.githubusercontent.com/46503462/103415168-3b23d300-4b81-11eb-80b4-aee557f0e9ba.png)

As well as to provide much more control over the syntax highlighting of the tool wrappers and their embedded languages. We can even use [injected grammars](https://github.com/galaxyproject/galaxy-language-server/compare/syntax-highlight?expand=1#diff-214147c50fe2c2896de3a3f2da1f7084bb881fd7a5655fe4c52369bcab51d098) to highlight certain elements like `tokens` in all of the [relevant languages](https://github.com/galaxyproject/galaxy-language-server/compare/syntax-highlight?expand=1#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fR82-R85).

The current result will be something like this:
![image](https://user-images.githubusercontent.com/46503462/103416187-dc148d00-4b85-11eb-96fc-2e030af05461.png)
![image](https://user-images.githubusercontent.com/46503462/103416204-ee8ec680-4b85-11eb-852e-256c36d8f40b.png)



