### PR TITLE
Fix wrong insert position for auto-generated code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ Whenever you write a closing ``>`` the corresponding closing tag will be inserte
 Snippets can be really helpful to speed up your tool wrapper development. They allow to quickly create common blocks and let you enter just the important information by pressing ``tab`` and navigating to the next available value.
 >If you want to add more snippets check the [guide](./docs/CONTRIBUTING.md#adding-snippets) in the contribution guidelines.
 
+### Embedded syntax highlighting
+
+![Demo feature embedded syntax highlighting](../assets/feature.embedded.syntax.png)
+
+Basic support for `Cheetah` and `reStructuredText` syntax highlighting inside the `<command>`, `<configfile>` and `<help>` tags. The embedded code should be inside a `CDATA` block.
+
+### Auto-generate tests
+
+![Demo feature auto-generate tests](../assets/feature.generate.tests.gif)
+
+After you define the `<inputs>` and `<outputs>` of the tool, you can press `Ctrl+Alt+t` (or `Cmd+Alt+t` in Mac) to create a `<tests>` section with a basic structure and some test cases. This is especially useful when using conditionals and other nested parameters since you can get right aways most of the bolerplate XML.
+
+### Auto-generate command section
+
+![Demo feature auto-generate command section](../assets/feature.generate.command.gif)
+
+Similar to the [auto-generate tests](#Auto-generate-tests) command, but this time it will generate boilerplate `Cheetah` code for the `<command>` section.
+
 ---
 
 # Getting Started

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -5,7 +5,7 @@ from pygls.types import Position, Range
 from pygls.workspace import Document
 from galaxyls.services.tools.constants import INPUTS, OUTPUTS
 from galaxyls.services.tools.inputs import GalaxyToolInputTree
-from galaxyls.services.xml.nodes import XmlElement
+from galaxyls.services.xml.nodes import XmlContainerNode, XmlElement
 
 from galaxyls.services.xml.types import DocumentType
 from galaxyls.services.xml.document import XmlDocument
@@ -65,7 +65,7 @@ class GalaxyToolXmlDocument:
         node = find(self.xml_document, filter_=lambda node: node.name == name, maxlevel=maxlevel)
         return cast(XmlElement, node)
 
-    def get_element_content_range(self, element: Optional[XmlElement]) -> Optional[Range]:
+    def get_content_range(self, element: Optional[XmlContainerNode]) -> Optional[Range]:
         """Returns the Range of the content block of the given element.
 
         Args:
@@ -76,7 +76,7 @@ class GalaxyToolXmlDocument:
         """
         if not element:
             return None
-        return self.xml_document.get_element_content_range(element)
+        return self.xml_document.get_content_range(element)
 
     def get_position_before(self, element: XmlElement) -> Position:
         """Returns the document position right before the given element opening tag.

--- a/server/galaxyls/services/tools/generators/command.py
+++ b/server/galaxyls/services/tools/generators/command.py
@@ -51,8 +51,8 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
         Returns:
             Optional[str]: The code snippet in TextMate format or None if the generation failed.
         """
-        input_tree = self.tool_document.analyze_inputs()
-        outputs = self.tool_document.get_outputs()
+        input_tree = self.expanded_document.analyze_inputs()
+        outputs = self.expanded_document.get_outputs()
         result_snippet = self._generate_command_snippet(input_tree, outputs)
         command_section = self.tool_document.find_element(COMMAND)
         if command_section and not command_section.is_self_closed:

--- a/server/galaxyls/services/tools/generators/command.py
+++ b/server/galaxyls/services/tools/generators/command.py
@@ -56,7 +56,9 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
         result_snippet = self._generate_command_snippet(input_tree, outputs)
         command_section = self.tool_document.find_element(COMMAND)
         if command_section and not command_section.is_self_closed:
-            return result_snippet
+            if command_section.get_cdata_section():
+                return result_snippet
+            return f"<![CDATA[\n\n{result_snippet}\n\n]]>\n"
         return f"<{COMMAND}><![CDATA[\n\n{result_snippet}\n\n]]>\n</{COMMAND}>\n"
 
     def _find_snippet_insert_position(self) -> Union[Position, Range]:
@@ -73,8 +75,11 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
         tool = self.tool_document
         section = tool.find_element(COMMAND)
         if section:
-            content_range = tool.get_element_content_range(section)
+            content_range = tool.get_content_range(section)
             if content_range:
+                cdata = section.get_cdata_section()
+                if cdata:
+                    content_range = tool.get_content_range(cdata)
                 return content_range.end
             else:  # is self closed <tests/>
                 start = tool.get_position_before(section)
@@ -92,7 +97,7 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
                 return tool.get_position_before(section)
             section = tool.find_element(TOOL)
             if section:
-                return tool.get_element_content_range(section).end
+                return tool.get_content_range(section).end
             return Position()
 
     def _generate_command_snippet(self, input_tree: GalaxyToolInputTree, outputs: List[XmlElement]) -> str:

--- a/server/galaxyls/services/tools/generators/snippets.py
+++ b/server/galaxyls/services/tools/generators/snippets.py
@@ -15,7 +15,8 @@ class SnippetGenerator(ABC):
     snippets using the information of the tool document."""
 
     def __init__(self, tool_document: GalaxyToolXmlDocument, tabSize: int = 4) -> None:
-        self.tool_document: GalaxyToolXmlDocument = self._get_expanded_tool_document(tool_document)
+        self.tool_document: GalaxyToolXmlDocument = tool_document
+        self.expanded_document: GalaxyToolXmlDocument = self._get_expanded_tool_document(tool_document)
         self.tabstop_count: int = 0
         self.indent_spaces: str = " " * tabSize
         super().__init__()

--- a/server/galaxyls/services/tools/generators/tests.py
+++ b/server/galaxyls/services/tools/generators/tests.py
@@ -65,8 +65,8 @@ class GalaxyToolTestSnippetGenerator(SnippetGenerator):
         Returns:
             Optional[str]: The code snippet in TextMate format or None if the generation failed.
         """
-        input_tree = self.tool_document.analyze_inputs()
-        outputs = self.tool_document.get_outputs()
+        input_tree = self.expanded_document.analyze_inputs()
+        outputs = self.expanded_document.get_outputs()
         result_snippet = "\n".join((self._generate_test_case_snippet(input_node, outputs) for input_node in input_tree.leaves))
         tests_section = self.tool_document.find_element(TESTS)
         if tests_section and not tests_section.is_self_closed:

--- a/server/galaxyls/services/tools/generators/tests.py
+++ b/server/galaxyls/services/tools/generators/tests.py
@@ -87,7 +87,7 @@ class GalaxyToolTestSnippetGenerator(SnippetGenerator):
         tool = self.tool_document
         section = tool.find_element(TESTS)
         if section:
-            content_range = tool.get_element_content_range(section)
+            content_range = tool.get_content_range(section)
             if content_range:
                 return content_range.end
             else:  # is self closed <tests/>
@@ -103,7 +103,7 @@ class GalaxyToolTestSnippetGenerator(SnippetGenerator):
                 return tool.get_position_after(section)
             section = tool.find_element(TOOL)
             if section:
-                return tool.get_element_content_range(section).end
+                return tool.get_content_range(section).end
             return Position()
 
     def _generate_test_case_snippet(self, input_node: InputNode, outputs: List[XmlElement]) -> str:

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -5,7 +5,7 @@ from lxml import etree
 from pygls.types import Position, Range
 from pygls.workspace import Document
 
-from .nodes import XmlElement, XmlSyntaxNode
+from .nodes import XmlContainerNode, XmlElement, XmlSyntaxNode
 from .types import DocumentType, NodeType
 from .utils import convert_document_offset_to_position, convert_document_offsets_to_range
 
@@ -81,11 +81,11 @@ class XmlDocument(XmlSyntaxNode):
         """Gets the syntax node a the given offset."""
         return self.root.find_node_at(offset)
 
-    def get_element_content_range(self, element: XmlElement) -> Optional[Range]:
+    def get_content_range(self, element: XmlContainerNode) -> Optional[Range]:
         """Gets the Range positions for the given XML element's content in the document.
 
         Args:
-            element (XmlElement): The XML element to determine it's content range positions.
+            element (XmlContainerNode): The XML element to determine it's content range positions.
 
         Returns:
             Optional[Range]: The range positions for the content of the given XML element.

--- a/server/galaxyls/tests/unit/test_tools.py
+++ b/server/galaxyls/tests/unit/test_tools.py
@@ -52,7 +52,7 @@ class TestGalaxyToolXmlDocumentClass:
         tool = GalaxyToolXmlDocument(document)
         node = tool.find_element("unknown")
 
-        actual = tool.get_element_content_range(node)
+        actual = tool.get_content_range(node)
 
         assert actual is None
 
@@ -71,7 +71,7 @@ class TestGalaxyToolXmlDocumentClass:
         tool = GalaxyToolXmlDocument(document)
         node = tool.find_element(element)
 
-        actual = tool.get_element_content_range(node)
+        actual = tool.get_content_range(node)
 
         assert actual == expected
 

--- a/server/galaxyls/tests/unit/test_tools.py
+++ b/server/galaxyls/tests/unit/test_tools.py
@@ -188,6 +188,24 @@ class TestGalaxyToolTestSnippetGeneratorClass:
 
         assert actual_position == expected_position
 
+    def test_generate_snippet_without_tests_section_returns_tests_tag(self) -> None:
+        document = TestUtils.to_document("<tool></tool>")
+        tool = GalaxyToolXmlDocument(document)
+        generator = GalaxyToolTestSnippetGenerator(tool)
+
+        result = generator.generate_snippet()
+
+        assert "<tests>" in result.snippet
+
+    def test_generate_snippet_with_tests_section_returns_snippet_only(self) -> None:
+        document = TestUtils.to_document("<tool><tests></tests></tool>")
+        tool = GalaxyToolXmlDocument(document)
+        generator = GalaxyToolTestSnippetGenerator(tool)
+
+        result = generator.generate_snippet()
+
+        assert "<tests>" not in result.snippet
+
 
 class TestGalaxyToolCommandSnippetGeneratorClass:
     @pytest.mark.parametrize(
@@ -219,6 +237,7 @@ class TestGalaxyToolCommandSnippetGeneratorClass:
             ("<tool></tool>", Position(0, 6)),
             ("<tool><description/><inputs></tool>", Position(0, 20)),
             ("<tool><command></command></tool>", Position(0, 15)),
+            ("<tool><command><![CDATA[]]></command></tool>", Position(0, 24)),
             ("<tool><command/></tool>", Range(Position(0, 6), Position(0, 16))),
         ],
     )
@@ -230,3 +249,33 @@ class TestGalaxyToolCommandSnippetGeneratorClass:
         actual_position = generator._find_snippet_insert_position()
 
         assert actual_position == expected_position
+
+    def test_generate_snippet_without_command_returns_command_tag_with_cdata(self) -> None:
+        document = TestUtils.to_document("<tool></tool>")
+        tool = GalaxyToolXmlDocument(document)
+        generator = GalaxyToolCommandSnippetGenerator(tool)
+
+        result = generator.generate_snippet()
+
+        assert "<command" in result.snippet
+        assert "<![CDATA[" in result.snippet
+
+    def test_generate_snippet_with_command_no_cdata_returns_cdata(self) -> None:
+        document = TestUtils.to_document("<tool><command></command></tool>")
+        tool = GalaxyToolXmlDocument(document)
+        generator = GalaxyToolCommandSnippetGenerator(tool)
+
+        result = generator.generate_snippet()
+
+        assert "<command" not in result.snippet
+        assert "<![CDATA[" in result.snippet
+
+    def test_generate_snippet_with_command_with_cdata_returns_snippet_only(self) -> None:
+        document = TestUtils.to_document("<tool><command><![CDATA[]]></command></tool>")
+        tool = GalaxyToolXmlDocument(document)
+        generator = GalaxyToolCommandSnippetGenerator(tool)
+
+        result = generator.generate_snippet()
+
+        assert "<command" not in result.snippet
+        assert "<![CDATA[" not in result.snippet


### PR DESCRIPTION
This PR fixes #82 by using the `unexpanded` tool document to calculate the insert position inside the document.

An improvement for the auto-generation of the `<command>` section that takes into account the CDATA block has been added. This will include (or omit) the CDATA block in the resulting snippet as needed.