### PR TITLE
Fix autoclose tags and autocompletion behaviour

### DIFF
--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -2,6 +2,7 @@
 
 from typing import Optional
 
+from galaxyls.services.xml.nodes import XmlCDATASection
 from pygls.types import (
     CompletionContext,
     CompletionItem,
@@ -29,7 +30,9 @@ class XmlCompletionService:
 
     def get_completion_at_context(
         self, context: XmlContext, completion_context: CompletionContext, mode: CompletionMode = CompletionMode.AUTO
-    ) -> CompletionList:
+    ) -> Optional[CompletionList]:
+        if isinstance(context.token, XmlCDATASection):
+            return None
         triggerKind = completion_context.triggerKind
         if mode == CompletionMode.AUTO and triggerKind == CompletionTriggerKind.TriggerCharacter:
             if completion_context.triggerCharacter == "<":
@@ -43,7 +46,7 @@ class XmlCompletionService:
                 if context.token.name:
                     return self.get_attribute_completion(context)
                 return self.get_node_completion(context)
-        return CompletionList(items=[], is_incomplete=False)
+        return None
 
     def get_node_completion(self, context: XmlContext) -> CompletionList:
         """Gets a list of completion items with all the available child tags
@@ -117,6 +120,8 @@ class XmlCompletionService:
 
     def get_auto_close_tag(self, context: XmlContext, trigger_character: str) -> Optional[AutoCloseTagResult]:
         """Gets the closing result for the currently opened tag in context."""
+        if isinstance(context.token, XmlCDATASection):
+            return None
         tag = context.xsd_element.name
         snippet = f"$0</{tag}>"
         replace_range = None

--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -34,7 +34,7 @@ class XmlCompletionService:
         if isinstance(context.token, XmlCDATASection):
             return None
         triggerKind = completion_context.triggerKind
-        if mode == CompletionMode.AUTO and triggerKind == CompletionTriggerKind.TriggerCharacter:
+        if mode == CompletionMode.AUTO and triggerKind == CompletionTriggerKind.TriggerCharacter and not context.is_attribute:
             if completion_context.triggerCharacter == "<":
                 return self.get_node_completion(context)
             if completion_context.triggerCharacter == " ":
@@ -120,8 +120,14 @@ class XmlCompletionService:
 
     def get_auto_close_tag(self, context: XmlContext, trigger_character: str) -> Optional[AutoCloseTagResult]:
         """Gets the closing result for the currently opened tag in context."""
-        if isinstance(context.token, XmlCDATASection):
+        if (
+            isinstance(context.token, XmlCDATASection)
+            or context.is_closing_tag
+            or context.is_attribute
+            or context.token.is_closed
+        ):
             return None
+
         tag = context.xsd_element.name
         snippet = f"$0</{tag}>"
         replace_range = None

--- a/server/galaxyls/services/context.py
+++ b/server/galaxyls/services/context.py
@@ -75,6 +75,11 @@ class XmlContext:
         return self._node is not None and self._node.node_type == NodeType.ELEMENT
 
     @property
+    def is_attribute(self) -> bool:
+        """Indicates if the token in context is an attribute."""
+        return self._node is not None and self._node.is_attribute
+
+    @property
     def is_attribute_key(self) -> bool:
         """Indicates if the token in context is an attribute key."""
         return self._node is not None and self._node.node_type == NodeType.ATTRIBUTE_KEY

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -59,7 +59,9 @@ class GalaxyToolLanguageService:
         """
         return self.format_service.format(content, params)
 
-    def get_completion(self, xml_document: XmlDocument, params: CompletionParams, mode: CompletionMode) -> CompletionList:
+    def get_completion(
+        self, xml_document: XmlDocument, params: CompletionParams, mode: CompletionMode
+    ) -> Optional[CompletionList]:
         """Gets completion items depending on the current document context."""
         context = self.xml_context_service.get_xml_context(xml_document, params.position)
         return self.completion_service.get_completion_at_context(context, params.context, mode)

--- a/server/galaxyls/services/xml/nodes.py
+++ b/server/galaxyls/services/xml/nodes.py
@@ -26,6 +26,11 @@ class XmlSyntaxNode(ABC, NodeMixin):
         return self.node_type == NodeType.ELEMENT
 
     @property
+    def is_attribute(self) -> bool:
+        """Indicates if this node is an attribute node."""
+        return self.node_type in [NodeType.ATTRIBUTE, NodeType.ATTRIBUTE_KEY, NodeType.ATTRIBUTE_VALUE]
+
+    @property
     def has_attributes(self) -> bool:
         """Indicates if this node has any attributes defined."""
         return False


### PR DESCRIPTION
This should fix #84 and other broken behaviors inside CDATA blocks that were not properly adapted to the new XML parsing system.