### PR TITLE
Fix input tree with nested conditional sharing the same 'when' value

### DIFF
--- a/server/galaxyls/services/tools/inputs.py
+++ b/server/galaxyls/services/tools/inputs.py
@@ -175,7 +175,9 @@ class GalaxyToolInputTree:
         name = conditional.get_attribute(NAME)
         if name and option_value:
             conditional_node = ConditionalInputNode(name, option_value, element=conditional, parent=parent)
-            when = find(conditional, filter_=lambda el: el.name == WHEN and el.get_attribute(VALUE) == option_value)
+            when = find(
+                conditional, filter_=lambda el: el.name == WHEN and el.get_attribute(VALUE) == option_value, maxlevel=2
+            )
             when = cast(XmlElement, when)
             if when:
                 self._build_input_tree(when, conditional_node)

--- a/server/galaxyls/tests/files/nested_conditional_bug_01.xml
+++ b/server/galaxyls/tests/files/nested_conditional_bug_01.xml
@@ -1,0 +1,28 @@
+<tool id="nested_conditional_bug_01" name="Nested conditional bug 01">
+    <description>Nested conditional with the same 'when' values should return the correct 'when'.</description>
+    <inputs>
+        <conditional name="parent_conditional">
+            <param name="option" type="select">
+                <option value="yes">Yes</option>
+                <option value="no">No</option>
+            </param>
+            <when value="yes">
+                <conditional name="child_conditional">
+                    <param name="option" type="select">
+                        <option value="yes">Yes</option>
+                        <option value="no">No</option>
+                    </param>
+                    <when value="yes">
+                        <param name="param" type="text"/>
+                    </when>
+                    <when value="no">
+                    </when>
+                </conditional>
+            </when>
+            <when value="no">
+            </when>
+        </conditional>
+    </inputs>
+    <tests>
+    </tests>
+</tool>

--- a/server/galaxyls/tests/files/nested_conditional_bug_01_command.xml
+++ b/server/galaxyls/tests/files/nested_conditional_bug_01_command.xml
@@ -1,0 +1,20 @@
+<command><![CDATA[
+
+## Auto-generated command section
+## TODO: please review and edit this section as needed
+
+## Inputs
+
+#if str( \$parent_conditional.option ) == "yes":
+    #if str( \$parent_conditional.child_conditional.option ) == "yes":
+        ${1:TODO_argument} '\$parent_conditional.child_conditional.param'
+    #elif str( \$parent_conditional.child_conditional.option ) == "no":
+    #end if
+#elif str( \$parent_conditional.option ) == "no":
+#end if
+
+## Outputs
+
+
+]]>
+</command>

--- a/server/galaxyls/tests/files/nested_conditional_bug_01_test.xml
+++ b/server/galaxyls/tests/files/nested_conditional_bug_01_test.xml
@@ -1,0 +1,27 @@
+<test expect_num_outputs="$1">
+    <!--TODO: auto-generated test case. Please fill in the required values-->
+    <conditional name="parent_conditional">
+        <param name="option" value="yes"/>
+        <conditional name="child_conditional">
+            <param name="option" value="yes"/>
+            <param name="param" value="$2"/>
+        </conditional>
+    </conditional>
+</test>
+
+<test expect_num_outputs="$3">
+    <!--TODO: auto-generated test case. Please fill in the required values-->
+    <conditional name="parent_conditional">
+        <param name="option" value="yes"/>
+        <conditional name="child_conditional">
+            <param name="option" value="no"/>
+        </conditional>
+    </conditional>
+</test>
+
+<test expect_num_outputs="$4">
+    <!--TODO: auto-generated test case. Please fill in the required values-->
+    <conditional name="parent_conditional">
+        <param name="option" value="no"/>
+    </conditional>
+</test>

--- a/server/galaxyls/tests/unit/test_tools.py
+++ b/server/galaxyls/tests/unit/test_tools.py
@@ -158,6 +158,7 @@ class TestGalaxyToolTestSnippetGeneratorClass:
             ("simple_output_01.xml", "simple_output_01_test.xml"),
             ("simple_output_02.xml", "simple_output_02_test.xml"),
             ("complex_inputs_01.xml", "complex_inputs_01_test.xml"),
+            ("nested_conditional_bug_01.xml", "nested_conditional_bug_01_test.xml"),
         ],
     )
     def test_build_snippet_returns_expected_result(self, tool_file: str, expected_snippet_file: str) -> None:
@@ -167,7 +168,7 @@ class TestGalaxyToolTestSnippetGeneratorClass:
         generator = GalaxyToolTestSnippetGenerator(tool)
 
         actual_snippet = generator._build_snippet()
-
+        print(actual_snippet)
         assert actual_snippet == expected_snippet
 
     @pytest.mark.parametrize(
@@ -219,6 +220,7 @@ class TestGalaxyToolCommandSnippetGeneratorClass:
             ("simple_output_01.xml", "simple_output_01_command.xml"),
             ("simple_output_02.xml", "simple_output_02_command.xml"),
             ("complex_inputs_01.xml", "complex_inputs_01_command.xml"),
+            ("nested_conditional_bug_01.xml", "nested_conditional_bug_01_test.xml"),
         ],
     )
     def test_build_snippet_returns_expected_result(self, tool_file: str, expected_snippet_file: str) -> None:
@@ -228,7 +230,7 @@ class TestGalaxyToolCommandSnippetGeneratorClass:
         generator = GalaxyToolCommandSnippetGenerator(tool)
 
         actual_snippet = generator._build_snippet()
-
+        print(actual_snippet)
         assert actual_snippet == expected_snippet
 
     @pytest.mark.parametrize(

--- a/server/galaxyls/tests/unit/test_tools.py
+++ b/server/galaxyls/tests/unit/test_tools.py
@@ -220,7 +220,7 @@ class TestGalaxyToolCommandSnippetGeneratorClass:
             ("simple_output_01.xml", "simple_output_01_command.xml"),
             ("simple_output_02.xml", "simple_output_02_command.xml"),
             ("complex_inputs_01.xml", "complex_inputs_01_command.xml"),
-            ("nested_conditional_bug_01.xml", "nested_conditional_bug_01_test.xml"),
+            ("nested_conditional_bug_01.xml", "nested_conditional_bug_01_command.xml"),
         ],
     )
     def test_build_snippet_returns_expected_result(self, tool_file: str, expected_snippet_file: str) -> None:


### PR DESCRIPTION
When finding the `when` clause associated with a `conditional`, the search was returning multiple possible values instead of the expected in the case of nested conditional with the same `when` value names like:

````xml
<conditional name="parent_conditional">
    <param name="option" type="select">
        <option value="yes">Yes</option>
        <option value="no">No</option>
    </param>
    <when value="yes">  <---------------------------- This
        <conditional name="child_conditional">
            <param name="option" type="select">
                <option value="yes">Yes</option>
                <option value="no">No</option>
            </param>
            <when value="yes">  <---------------------------- This
                <param name="param" type="text"/>
            </when>
            <when value="no">
            </when>
        </conditional>
    </when>
    <when value="no">
    </when>
</conditional>
````