### PR TITLE
Hide command and view contributions when the extension is not active

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -90,27 +90,32 @@
       {
         "command": "galaxytools.generate.tests",
         "title": "Generate tests cases for current tool",
-        "category": "Galaxy Tools"
+        "category": "Galaxy Tools",
+        "enablement": "galaxytools:isActive"
       },
       {
         "command": "galaxytools.generate.command",
         "title": "Generate boilerplate command section for current tool",
-        "category": "Galaxy Tools"
+        "category": "Galaxy Tools",
+        "enablement": "galaxytools:isActive"
       },
       {
         "command": "galaxytools.sort.singleParamAttributes",
         "title": "Sort the attributes of the param element under the cursor according to the IUC Coding Style Guide.",
-        "category": "Galaxy Tools"
+        "category": "Galaxy Tools",
+        "enablement": "galaxytools:isActive"
       },
       {
         "command": "galaxytools.sort.documentParamsAttributes",
         "title": "Sort the attributes of all the param elements in the document according to the IUC Coding Style Guidelines.",
-        "category": "Galaxy Tools"
+        "category": "Galaxy Tools",
+        "enablement": "galaxytools:isActive"
       },
       {
         "command": "galaxytools.planemo.openSettings",
         "title": "Displays the configuration settings for `planemo`.",
-        "category": "Galaxy Tools: Planemo"
+        "category": "Galaxy Tools: Planemo",
+        "enablement": "galaxytools:isActive"
       }
     ],
     "keybindings": [
@@ -207,7 +212,7 @@
         {
           "id": "planemo-config",
           "name": "Configuration",
-          "when": "config.galaxyTools.planemo.enabled"
+          "when": "galaxytools:isActive && config.galaxyTools.planemo.enabled"
         }
       ]
     },

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -72,6 +72,8 @@ export function setupCommands(client: LanguageClient, context: ExtensionContext)
 
     // Open planemo settings
     context.subscriptions.push(commands.registerCommand(Commands.PLANEMO_OPEN_SETTINGS, openPlanemoSettings))
+
+    notifyExtensionActive();
 }
 
 async function requestSortSingleParamAttrs(client: LanguageClient, request: RequestType<TextDocumentPositionParams, ReplaceTextRangeResult, any, any>) {
@@ -169,4 +171,8 @@ function ensureDocumentIsSaved(editor: TextEditor): Boolean {
 
 function openPlanemoSettings() {
     commands.executeCommand('workbench.action.openSettings', 'galaxyTools.planemo');
+}
+
+function notifyExtensionActive() {
+    commands.executeCommand('setContext', 'galaxytools:isActive', true);
 }


### PR DESCRIPTION
If you have the `Galaxy Tools` extension installed, the planemo icon in the left activity bar and all the extension's commands are shown in the command palette even if the extension is not active (i.e. your current workspace or opened folder does not contain any XML tool documents).

This fixes #116 by enabling those views and commands only when the extension has been properly loaded.

![pr](https://user-images.githubusercontent.com/46503462/108196254-30190800-7119-11eb-8e05-a1c952327fa4.gif)
