### PR TITLE
Detach client and server versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,6 @@ jobs:
 
       - name: Package and Upload to PyPI
         env:
-          # This env variable will be used to set the version in setup.py
-          GALAXYLS_VERSION: ${{ needs.prepare_release.outputs.release_version }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
             - Galaxy Language Server [changelog](https://github.com/davelopez/galaxy-language-server/blob/master/server/CHANGELOG.md)
             - Galaxy Tools Visual Studio Extension [changelog](https://github.com/davelopez/galaxy-language-server/blob/master/client/CHANGELOG.md#)
 
-            This version of the language server is available as a PyPI package and can be installed using:
+            This version of the language server is available as a [PyPI package](https://pypi.org/project/galaxy-language-server/) and can be installed using:
             ```
             python3 -m pip install galaxy-language-server==${{ steps.get_version.outputs.version-without-v }}
             ```
@@ -77,7 +77,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python setup.py sdist bdist_wheel
-          twine upload dist/*
+          twine upload --skip-existing dist/*
 
   publish-client:
     name: Publish extension to Open-VSX and VSCode Marketplace

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,17 +1,14 @@
-import { extensions } from "vscode";
 
-export const EXTENSION_JSON = extensions.getExtension("davelopez.galaxy-tools")?.packageJSON;
-export const EXTENSION_NAME = EXTENSION_JSON.displayName;
-export const EXTENSION_VERSION = EXTENSION_JSON.version;
+export namespace Constants {
+    export const IS_WIN = process.platform === "win32";
+    export const LS_VENV_NAME = "glsenv";
+    export const GALAXY_LS_PACKAGE = "galaxy-language-server";
+    export const GALAXY_LS = "galaxyls";
+    export const GALAXY_LS_VERSION = "0.4.0"
+    export const LANGUAGE_ID = "galaxytool"
+    export const TOOL_DOCUMENT_EXTENSION = "xml"
 
-export const IS_WIN = process.platform === "win32";
-export const LS_VENV_NAME = "glsenv";
-export const GALAXY_LS_PACKAGE = "galaxy-language-server";
-export const GALAXY_LS = "galaxyls";
-export const GALAXY_LS_VERSION = "0.4.0"
-export const LANGUAGE_ID = "galaxytool"
-export const TOOL_DOCUMENT_EXTENSION = "xml"
-
-export const PYTHON_UNIX = "python3";
-export const PYTHON_WIN = "python.exe";
-export const REQUIRED_PYTHON_VERSION = "3.8+";
+    export const PYTHON_UNIX = "python3";
+    export const PYTHON_WIN = "python.exe";
+    export const REQUIRED_PYTHON_VERSION = "3.8+";
+}

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -8,7 +8,7 @@ export const IS_WIN = process.platform === "win32";
 export const LS_VENV_NAME = "glsenv";
 export const GALAXY_LS_PACKAGE = "galaxy-language-server";
 export const GALAXY_LS = "galaxyls";
-export const GALAXY_LS_VERSION = EXTENSION_VERSION; // The Extension and Language Server versions should always match
+export const GALAXY_LS_VERSION = "0.4.0"
 export const LANGUAGE_ID = "galaxytool"
 export const TOOL_DOCUMENT_EXTENSION = "xml"
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,7 +5,7 @@ import { ExtensionContext, window, TextDocument, Position, IndentAction, Languag
 import { LanguageClient, LanguageClientOptions, ServerOptions } from "vscode-languageclient";
 import { activateTagClosing, TagCloseRequest } from './tagClosing';
 import { installLanguageServer } from './setup';
-import { GALAXY_LS, LANGUAGE_ID } from './constants';
+import { Constants } from './constants';
 import { setupCommands } from './commands';
 import { setupPlanemo } from "./planemo/main";
 import { DefaultConfigurationFactory } from "./planemo/configuration";
@@ -30,7 +30,7 @@ export async function activate(context: ExtensionContext) {
         return;
       }
 
-      client = startLanguageServer(python, ["-m", GALAXY_LS], context.extensionPath);
+      client = startLanguageServer(python, ["-m", Constants.GALAXY_LS], context.extensionPath);
 
     } catch (err) {
       window.showErrorMessage(err);
@@ -38,7 +38,7 @@ export async function activate(context: ExtensionContext) {
   }
 
   // Configure auto-indentation
-  languages.setLanguageConfiguration(LANGUAGE_ID, getIndentationRules());
+  languages.setLanguageConfiguration(Constants.LANGUAGE_ID, getIndentationRules());
 
   context.subscriptions.push(client.start());
 
@@ -73,8 +73,8 @@ function getClientOptions(): LanguageClientOptions {
   return {
     // Register the server for xml documents
     documentSelector: [
-      { scheme: "file", language: LANGUAGE_ID },
-      { scheme: "untitled", language: LANGUAGE_ID },
+      { scheme: "file", language: Constants.LANGUAGE_ID },
+      { scheme: "untitled", language: Constants.LANGUAGE_ID },
     ],
     outputChannelName: "[galaxyls]",
     synchronize: {

--- a/client/src/planemo/testing/testAdapter.ts
+++ b/client/src/planemo/testing/testAdapter.ts
@@ -2,7 +2,7 @@
 
 import { WorkspaceFolder, Event, EventEmitter, workspace, window, TextDocument } from "vscode";
 import { RetireEvent, TestAdapter, TestEvent, TestLoadFinishedEvent, TestLoadStartedEvent, TestRunFinishedEvent, TestRunStartedEvent, TestSuiteEvent, TestSuiteInfo } from "vscode-test-adapter-api";
-import { LANGUAGE_ID, TOOL_DOCUMENT_EXTENSION } from "../../constants";
+import { Constants } from "../../constants";
 import { TestState } from "../../testing/common";
 import { ITestRunner } from "../../testing/testRunner";
 import { ITestsProvider } from "../../testing/testsProvider";
@@ -201,7 +201,7 @@ export class PlanemoTestAdapter implements TestAdapter {
     }
 
     private isToolDocument(document: TextDocument): boolean {
-        return document.languageId === LANGUAGE_ID
-            && document.fileName.endsWith(TOOL_DOCUMENT_EXTENSION);
+        return document.languageId === Constants.LANGUAGE_ID
+            && document.fileName.endsWith(Constants.TOOL_DOCUMENT_EXTENSION);
     }
 }

--- a/client/src/planemo/testing/testRunner.ts
+++ b/client/src/planemo/testing/testRunner.ts
@@ -2,7 +2,7 @@ import { unlinkSync } from 'fs';
 import * as path from 'path';
 import * as tmp from 'tmp';
 import { TestEvent, TestSuiteInfo } from 'vscode-test-adapter-api';
-import { TOOL_DOCUMENT_EXTENSION } from '../../constants';
+import { Constants } from '../../constants';
 import { IProcessExecution, runProcess } from '../../processRunner';
 import { ITestRunner } from '../../testing/testRunner';
 import { IPlanemoConfiguration } from '../configuration';
@@ -23,7 +23,7 @@ export class PlanemoTestRunner implements ITestRunner {
         }
 
         const testSuiteId = testSuite.id;
-        const testFile = testSuite.file ? testSuite.file : `${planemoConfig.getCwd()}/${testSuiteId}.${TOOL_DOCUMENT_EXTENSION}`;
+        const testFile = testSuite.file ? testSuite.file : `${planemoConfig.getCwd()}/${testSuiteId}.${Constants.TOOL_DOCUMENT_EXTENSION}`;
         try {
             const { file: output_json_file, cleanupCallback } = await this.getJsonReportPath(testFile);
 
@@ -77,7 +77,7 @@ export class PlanemoTestRunner implements ITestRunner {
     private async getJsonReportPath(testFile: string | undefined): Promise<{ file: string, cleanupCallback: () => void }> {
         if (testFile !== undefined) {
             const baseDir = path.dirname(testFile);
-            const testFileName = path.basename(testFile, TOOL_DOCUMENT_EXTENSION);
+            const testFileName = path.basename(testFile, Constants.TOOL_DOCUMENT_EXTENSION);
             const reportFile = path.resolve(baseDir, `${testFileName}json`);
 
             return Promise.resolve({

--- a/client/src/setup.ts
+++ b/client/src/setup.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { existsSync } from "fs";
 import { commands, ExtensionContext, ProgressLocation, Uri, window, workspace } from "vscode";
-import { IS_WIN, LS_VENV_NAME, GALAXY_LS_PACKAGE, PYTHON_UNIX, PYTHON_WIN, GALAXY_LS_VERSION, REQUIRED_PYTHON_VERSION } from "./constants";
+import { Constants } from "./constants";
 import { execAsync } from "./utils";
 
 /**
@@ -12,17 +12,17 @@ import { execAsync } from "./utils";
  */
 export async function installLanguageServer(context: ExtensionContext): Promise<string | undefined> {
     // Check if the LS is already installed
-    let venvPath = getVirtualEnvironmentPath(context.extensionPath, LS_VENV_NAME)
+    let venvPath = getVirtualEnvironmentPath(context.extensionPath, Constants.LS_VENV_NAME)
     if (existsSync(venvPath)) {
         const venvPython = getPythonFromVenvPath(venvPath);
-        const isInstalled = await isPythonPackageInstalled(venvPython, GALAXY_LS_PACKAGE, GALAXY_LS_VERSION);
+        const isInstalled = await isPythonPackageInstalled(venvPython, Constants.GALAXY_LS_PACKAGE, Constants.GALAXY_LS_VERSION);
         if (isInstalled) {
-            console.log(`[gls] ${GALAXY_LS_PACKAGE} already installed.`);
+            console.log(`[gls] ${Constants.GALAXY_LS_PACKAGE} already installed.`);
             return Promise.resolve(venvPython);
         }
     }
 
-    const result = await window.showInformationMessage(`Galaxy Tools needs to install the Galaxy Language Server Python package to continue. This will be installed in a virtual environment inside the extension and will require Python ${REQUIRED_PYTHON_VERSION}`, ...['Install', 'More Info']);
+    const result = await window.showInformationMessage(`Galaxy Tools needs to install the Galaxy Language Server Python package to continue. This will be installed in a virtual environment inside the extension and will require Python ${Constants.REQUIRED_PYTHON_VERSION}`, ...['Install', 'More Info']);
 
     if (result === undefined) {
         console.log(`[gls] Language server installation cancelled by the user.`);
@@ -45,26 +45,26 @@ export async function installLanguageServer(context: ExtensionContext): Promise<
 
                     if (python === undefined) {
                         await window.showInformationMessage(
-                            `Please select your Python ${REQUIRED_PYTHON_VERSION} path to continue the installation. This python will be used to create a virtual environment inside the extension directory.`,
+                            `Please select your Python ${Constants.REQUIRED_PYTHON_VERSION} path to continue the installation. This python will be used to create a virtual environment inside the extension directory.`,
                             ...['Select']);
                         python = await selectPythonUsingFileDialog();
                         // User canceled the input
                         if (python === undefined) {
-                            const message = `Python ${REQUIRED_PYTHON_VERSION} is required in order to use the language server features.`;
+                            const message = `Python ${Constants.REQUIRED_PYTHON_VERSION} is required in order to use the language server features.`;
                             window.showErrorMessage(message);
                             throw new Error(message);
                         }
                     }
 
                     console.log(`[gls] Creating virtual environment...`);
-                    venvPath = await createVirtualEnvironment(python, LS_VENV_NAME, context.extensionPath);
+                    venvPath = await createVirtualEnvironment(python, Constants.LS_VENV_NAME, context.extensionPath);
                 }
 
                 const venvPython = getPythonFromVenvPath(venvPath);
                 console.log(`[gls] Using Python from: ${venvPython}`);
 
-                console.log(`[gls] Installing ${GALAXY_LS_PACKAGE}...`);
-                const isInstalled = await intallPythonPackage(venvPython, GALAXY_LS_PACKAGE, GALAXY_LS_VERSION)
+                console.log(`[gls] Installing ${Constants.GALAXY_LS_PACKAGE}...`);
+                const isInstalled = await intallPythonPackage(venvPython, Constants.GALAXY_LS_PACKAGE, Constants.GALAXY_LS_VERSION)
 
                 if (!isInstalled) {
                     const errorMessage = "There was a problem trying to install the Galaxy language server.";
@@ -72,7 +72,7 @@ export async function installLanguageServer(context: ExtensionContext): Promise<
                     throw new Error(errorMessage);
                 }
 
-                console.log(`[gls] ${GALAXY_LS_PACKAGE} installed successfully.`);
+                console.log(`[gls] ${Constants.GALAXY_LS_PACKAGE} installed successfully.`);
                 window.showInformationMessage("Galaxy Tools extension is ready!");
                 resolve(venvPython);
             } catch (err) {
@@ -85,11 +85,11 @@ export async function installLanguageServer(context: ExtensionContext): Promise<
 }
 
 function getPythonFromVenvPath(venvPath: string): string {
-    return IS_WIN ? join(venvPath, "Scripts", PYTHON_WIN) : join(venvPath, "bin", PYTHON_UNIX);
+    return Constants.IS_WIN ? join(venvPath, "Scripts", Constants.PYTHON_WIN) : join(venvPath, "bin", Constants.PYTHON_UNIX);
 }
 
 function getPythonCrossPlatform(): string {
-    return IS_WIN ? PYTHON_WIN : PYTHON_UNIX;
+    return Constants.IS_WIN ? Constants.PYTHON_WIN : Constants.PYTHON_UNIX;
 }
 
 function getVirtualEnvironmentPath(extensionDirectory: string, envName: string): string {
@@ -156,7 +156,7 @@ async function getPython(): Promise<string | undefined> {
 async function selectPythonUsingFileDialog(): Promise<string | undefined> {
     let result = await window.showOpenDialog({
         openLabel: "Select", canSelectMany: false,
-        title: `Select the Python ${REQUIRED_PYTHON_VERSION} binary:`
+        title: `Select the Python ${Constants.REQUIRED_PYTHON_VERSION} binary:`
     });
 
     if (result !== undefined) {
@@ -165,7 +165,7 @@ async function selectPythonUsingFileDialog(): Promise<string | undefined> {
         if (await checkPythonVersion(pythonPath)) {
             return pythonPath;
         } else {
-            window.showErrorMessage(`The selected file is not a valid Python ${REQUIRED_PYTHON_VERSION} path!`);
+            window.showErrorMessage(`The selected file is not a valid Python ${Constants.REQUIRED_PYTHON_VERSION} path!`);
         }
     }
 

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,12 +1,11 @@
 """Galaxy Language Server Setup"""
 
-import os
 import pathlib
 from setuptools import setup, find_packages
 
 
 PACKAGE_NAME = "galaxy-language-server"
-VERSION = os.environ.get("GALAXYLS_VERSION", "0.0.0")
+VERSION = "0.4.0"
 AUTHOR = "David López"
 AUTHOR_EMAIL = "davelopez7391@gmail.com"
 DESCRIPTION = "A language server for Galaxy (https://galaxyproject.org) tool wrappers"


### PR DESCRIPTION
This will allow setting a specific server version used by a specific client version that doesn't need to match each other.

- The server version is no longer automated and now had to be manually set in each project as part of the release protocol.
- The tag version of the release will now exclusively match the client version.
- The server version will be updated in PyPi only when it changes.

Closes #118 