### PR TITLE
Add link to test html report in the output

### DIFF
--- a/client/src/planemo/testing/testRunner.ts
+++ b/client/src/planemo/testing/testRunner.ts
@@ -106,7 +106,8 @@ export class PlanemoTestRunner implements ITestRunner {
 
     private getTestHtmlReportFilePath(testFile: string): string {
         const baseDir = path.dirname(testFile);
-        const reportFile = path.resolve(baseDir, `tool_test_output.html`);
+        const testFileName = path.basename(testFile, Constants.TOOL_DOCUMENT_EXTENSION).replace(".", "");
+        const reportFile = path.resolve(baseDir, `${testFileName}_test_report.html`);
         return reportFile;
     }
 }

--- a/client/src/planemo/testing/testRunner.ts
+++ b/client/src/planemo/testing/testRunner.ts
@@ -26,12 +26,17 @@ export class PlanemoTestRunner implements ITestRunner {
         const testFile = testSuite.file ? testSuite.file : `${planemoConfig.getCwd()}/${testSuiteId}.${Constants.TOOL_DOCUMENT_EXTENSION}`;
         try {
             const { file: output_json_file, cleanupCallback } = await this.getJsonReportPath(testFile);
+            const htmlReportFile = this.getTestHtmlReportFilePath(testFile);
 
             const testRunArguments = [
                 `test`,
-                `--galaxy_root=${planemoConfig.galaxyRoot()}`,
-                `--test_output_json=${output_json_file}`,
-                testFile,
+                `--galaxy_root`,
+                `${planemoConfig.galaxyRoot()}`,
+                `--test_output_json`,
+                `${output_json_file}`,
+                `--test_output`,
+                `${htmlReportFile}`,
+                `${testFile}`,
             ]
 
             const testExecution = this.runPlanemoTest(planemoConfig, testRunArguments);
@@ -39,7 +44,7 @@ export class PlanemoTestRunner implements ITestRunner {
             this.testExecutions.set(testSuiteId, testExecution);
             await testExecution.complete();
 
-            const states = await parseTestStates(output_json_file, testSuite);
+            const states = await parseTestStates(output_json_file, testSuite, htmlReportFile);
 
             cleanupCallback();
 
@@ -97,5 +102,11 @@ export class PlanemoTestRunner implements ITestRunner {
                 resolve({ file, cleanupCallback });
             });
         });
+    }
+
+    private getTestHtmlReportFilePath(testFile: string): string {
+        const baseDir = path.dirname(testFile);
+        const reportFile = path.resolve(baseDir, `tool_test_output.html`);
+        return reportFile;
     }
 }

--- a/client/src/planemo/testing/testsReportParser.ts
+++ b/client/src/planemo/testing/testsReportParser.ts
@@ -46,13 +46,13 @@ interface ITestCaseJobInfo {
     tool_stdout: string;
 }
 
-export async function parseTestStates(outputJsonFile: string, testSuite: TestSuiteInfo): Promise<TestEvent[]> {
+export async function parseTestStates(outputJsonFile: string, testSuite: TestSuiteInfo, htmlReportFile: string): Promise<TestEvent[]> {
     const content = await readFile(outputJsonFile);
     const parseResult = await JSON.parse(content);
-    return parseTestResults(parseResult, testSuite);
+    return parseTestResults(parseResult, testSuite, htmlReportFile);
 }
 
-function parseTestResults(parserResult: any, testSuite: TestSuiteInfo): TestEvent[] {
+function parseTestResults(parserResult: any, testSuite: TestSuiteInfo, htmlReportFile: string): TestEvent[] {
     if (!parserResult) {
         return [];
     }
@@ -63,6 +63,7 @@ function parseTestResults(parserResult: any, testSuite: TestSuiteInfo): TestEven
         const testInfo = getTestInfo(testCaseResult, testSuite);
         const adatedResult = adaptTestResult(testCaseResult, testInfo);
         if (adatedResult !== undefined) {
+            adatedResult.message += `${EOL}${EOL}See full test report: ${htmlReportFile}`;
             testResults.push(adatedResult);
         }
     });


### PR DESCRIPTION
A `{tool_id}_test_report.html` file will be generated for each tool after running the tests from the Test Explorer.
In the output window of each test, a new link to this HTML report file will appear to inspect detailed information about the test results.

![image](https://user-images.githubusercontent.com/46503462/108915532-4d743780-762d-11eb-8802-403bb88a4270.png)

Closes #121 