### PR TITLE
Planemo Explorer Configuration View

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -115,7 +115,8 @@
         "command": "galaxytools.planemo.openSettings",
         "title": "Displays the configuration settings for `planemo`.",
         "category": "Galaxy Tools: Planemo",
-        "enablement": "galaxytools:isActive"
+        "enablement": "galaxytools:isActive",
+        "icon": "$(settings-gear)"
       }
     ],
     "keybindings": [
@@ -213,6 +214,15 @@
           "id": "planemo-config",
           "name": "Configuration",
           "when": "galaxytools:isActive && config.galaxyTools.planemo.enabled"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "galaxytools.planemo.openSettings",
+          "when": "view == planemo-config",
+          "group": "navigation"
         }
       ]
     },

--- a/client/package.json
+++ b/client/package.json
@@ -91,7 +91,8 @@
         "command": "galaxytools.generate.tests",
         "title": "Generate tests cases for current tool",
         "category": "Galaxy Tools",
-        "enablement": "galaxytools:isActive"
+        "enablement": "galaxytools:isActive",
+        "icon": "$(test-view-icon)"
       },
       {
         "command": "galaxytools.generate.command",
@@ -117,6 +118,13 @@
         "category": "Galaxy Tools: Planemo",
         "enablement": "galaxytools:isActive",
         "icon": "$(settings-gear)"
+      },
+      {
+        "command": "galaxytools.openTerminalAtDirectory",
+        "title": "Open this directory in a new terminal.",
+        "category": "Galaxy Tools",
+        "enablement": "galaxytools:isActive",
+        "icon": "$(terminal-view-icon)"
       }
     ],
     "keybindings": [
@@ -223,6 +231,13 @@
           "command": "galaxytools.planemo.openSettings",
           "when": "view == planemo-config",
           "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "galaxytools.openTerminalAtDirectory",
+          "when": "view == planemo-config && viewItem == directoryItem",
+          "group": "inline"
         }
       ]
     },

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -3,6 +3,7 @@
 import { window, Position, SnippetString, Range, ExtensionContext, commands, TextEditor } from "vscode";
 import { RequestType, TextDocumentIdentifier, TextDocumentPositionParams, LanguageClient } from "vscode-languageclient";
 import { cloneRange } from "./utils";
+import { DirectoryTreeItem } from "./views/common";
 
 export namespace Commands {
 
@@ -13,6 +14,7 @@ export namespace Commands {
     export const SORT_DOCUMENT_PARAMS_ATTRS = 'galaxytools.sort.documentParamsAttributes';
     export const DISCOVER_TESTS = 'galaxytools.tests.discover';
     export const PLANEMO_OPEN_SETTINGS = 'galaxytools.planemo.openSettings';
+    export const OPEN_TERMINAL_AT_DIRECTORY_ITEM = 'galaxytools.openTerminalAtDirectory';
 }
 
 namespace GeneratedTestRequest {
@@ -72,6 +74,8 @@ export function setupCommands(client: LanguageClient, context: ExtensionContext)
 
     // Open planemo settings
     context.subscriptions.push(commands.registerCommand(Commands.PLANEMO_OPEN_SETTINGS, openPlanemoSettings))
+
+    context.subscriptions.push(commands.registerCommand(Commands.OPEN_TERMINAL_AT_DIRECTORY_ITEM, (item: DirectoryTreeItem) => openTerminalAtDirectoryItem(item)))
 
     notifyExtensionActive();
 }
@@ -171,6 +175,13 @@ function ensureDocumentIsSaved(editor: TextEditor): Boolean {
 
 function openPlanemoSettings() {
     commands.executeCommand('workbench.action.openSettings', 'galaxyTools.planemo');
+}
+
+function openTerminalAtDirectoryItem(item: DirectoryTreeItem) {
+    let terminal = window.createTerminal({
+        cwd: item.directoryUri.fsPath
+    });
+    terminal.show(false);
 }
 
 function notifyExtensionActive() {

--- a/client/src/configuration/galaxyToolWorkspaceConfiguration.ts
+++ b/client/src/configuration/galaxyToolWorkspaceConfiguration.ts
@@ -32,7 +32,7 @@ class GalaxyToolsPlanemoConfiguration implements IPlanemoConfiguration {
     public enabled(): boolean {
         return this.config.get("planemo.enabled", true);
     }
-    public envPath(): string {
+    public binaryPath(): string {
         return this.config.get("planemo.envPath", "planemo");
     }
     public galaxyRoot(): string | null {
@@ -74,7 +74,7 @@ class GalaxyToolsPlanemoConfiguration implements IPlanemoConfiguration {
 
     private async isPlanemoInstalled(): Promise<boolean> {
         try {
-            const envPath = this.envPath();
+            const envPath = this.binaryPath();
             const isOnPath = await lookpath('planemo') !== undefined;
             return envPath !== null && envPath.endsWith("planemo") && (isOnPath || await exists(envPath));
         }

--- a/client/src/configuration/galaxyToolWorkspaceConfiguration.ts
+++ b/client/src/configuration/galaxyToolWorkspaceConfiguration.ts
@@ -51,7 +51,7 @@ class GalaxyToolsPlanemoConfiguration implements IPlanemoConfiguration {
     public async validate(): Promise<ConfigValidationResult> {
         const result = new ConfigValidationResult();
 
-        if (!this.isPlanemoInstalled()) {
+        if (!await this.isPlanemoInstalled()) {
             result.addErrorMessage("Please set a valid `envPath` value for planemo in the configuration.")
         }
 

--- a/client/src/configuration/workspaceConfiguration.ts
+++ b/client/src/configuration/workspaceConfiguration.ts
@@ -1,5 +1,26 @@
 import { IPlanemoConfiguration } from "../planemo/configuration";
 
+
+export namespace Settings {
+
+    export namespace Completion {
+        export const MODE = 'galaxyTools.completion.mode';
+        export const AUTO_CLOSE_TAGS = 'galaxytools.completion.autoCloseTags';
+    }
+
+    export namespace Planemo {
+        export const ENABLED = 'galaxyTools.planemo.enabled';
+        export const ENV_PATH = 'galaxyTools.planemo.envPath';
+        export const GALAXY_ROOT = 'galaxyTools.planemo.galaxyRoot';
+
+        export namespace Testing {
+            export const ENABLED = 'galaxyTools.planemo.testing.enabled';
+            export const AUTO_DISCOVERY_ON_SAVE_ENABLED = 'galaxyTools.planemo.testing.autoTestDiscoverOnSaveEnabled';
+        }
+    }
+}
+
+
 export interface IWorkspaceConfiguration {
 
     planemo(): IPlanemoConfiguration;
@@ -7,6 +28,18 @@ export interface IWorkspaceConfiguration {
 
 export class ConfigValidationResult {
     private readonly errorMessages: string[] = []
+
+    constructor(private validPlanemo: boolean, private validGalaxyRoot: boolean) {
+
+    }
+
+    public isValidPlanemo(): boolean {
+        return this.validPlanemo;
+    }
+
+    public isValidGalaxyRoot(): boolean {
+        return this.validGalaxyRoot;
+    }
 
     public isValid(): boolean {
         return this.errorMessages.length === 0;

--- a/client/src/planemo/configuration.ts
+++ b/client/src/planemo/configuration.ts
@@ -5,7 +5,7 @@ export interface IPlanemoConfiguration {
 
     enabled(): boolean;
 
-    envPath(): string;
+    binaryPath(): string;
 
     galaxyRoot(): string | null;
 

--- a/client/src/planemo/main.ts
+++ b/client/src/planemo/main.ts
@@ -4,8 +4,13 @@ import { ExtensionContext } from "vscode";
 import { LanguageClient } from "vscode-languageclient";
 import { IConfigurationFactory } from "./configuration";
 import { setupTesting } from "./testing/main";
+import { registerViews } from "./views/main";
 
 
 export function setupPlanemo(client: LanguageClient, context: ExtensionContext, configFactory: IConfigurationFactory) {
+
+    registerViews(client, context, configFactory);
+
     setupTesting(client, context, configFactory);
+
 }

--- a/client/src/planemo/testing/testAdapter.ts
+++ b/client/src/planemo/testing/testAdapter.ts
@@ -2,6 +2,7 @@
 
 import { WorkspaceFolder, Event, EventEmitter, workspace, window, TextDocument } from "vscode";
 import { RetireEvent, TestAdapter, TestEvent, TestLoadFinishedEvent, TestLoadStartedEvent, TestRunFinishedEvent, TestRunStartedEvent, TestSuiteEvent, TestSuiteInfo } from "vscode-test-adapter-api";
+import { Settings } from "../../configuration/workspaceConfiguration";
 import { Constants } from "../../constants";
 import { TestState } from "../../testing/common";
 import { ITestRunner } from "../../testing/testRunner";
@@ -43,10 +44,9 @@ export class PlanemoTestAdapter implements TestAdapter {
     private registerActions() {
         this.disposables.push(workspace.onDidChangeConfiguration(async configurationChange => {
             const sectionsToReload = [
-                'galaxyTools.planemo.enabled',
-                'galaxyTools.planemo.envPath',
-                'galaxyTools.planemo.galaxyRoot',
-                'galaxyTools.planemo.testing.enabled',
+                Settings.Planemo.ENV_PATH,
+                Settings.Planemo.GALAXY_ROOT,
+                Settings.Planemo.Testing.ENABLED,
             ];
 
             const needsReload = sectionsToReload.some(

--- a/client/src/planemo/testing/testAdapter.ts
+++ b/client/src/planemo/testing/testAdapter.ts
@@ -44,7 +44,7 @@ export class PlanemoTestAdapter implements TestAdapter {
         this.disposables.push(workspace.onDidChangeConfiguration(async configurationChange => {
             const sectionsToReload = [
                 'galaxyTools.planemo.enabled',
-                'galaxyTools.planemo.virtualEnv',
+                'galaxyTools.planemo.envPath',
                 'galaxyTools.planemo.galaxyRoot',
                 'galaxyTools.planemo.testing.enabled',
             ];

--- a/client/src/planemo/testing/testRunner.ts
+++ b/client/src/planemo/testing/testRunner.ts
@@ -74,7 +74,7 @@ export class PlanemoTestRunner implements ITestRunner {
     }
 
     private runPlanemoTest(planemoConfig: IPlanemoConfiguration, args: string[]): IProcessExecution {
-        const planemoPath = planemoConfig.envPath();
+        const planemoPath = planemoConfig.binaryPath();
         return runProcess(planemoPath, args, { cwd: planemoConfig.getCwd() });
 
     }

--- a/client/src/planemo/views/configurationView.ts
+++ b/client/src/planemo/views/configurationView.ts
@@ -3,8 +3,10 @@
 import { EOL } from 'os';
 import * as path from 'path';
 import { lookpath } from "lookpath"
+import { Event, EventEmitter, ExtensionContext, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri, window } from "vscode";
 import { execAsync, readFile } from '../../utils';
 import { IConfigurationFactory, IPlanemoConfiguration } from "../configuration";
+import { DirectoryTreeItem } from '../../views/common';
 
 const PLANEMO_LABEL = "Planemo";
 const GALAXY_LABEL = "Galaxy";
@@ -34,7 +36,6 @@ export class PlanemoConfigTreeItem extends TreeItem {
     }
 
 }
-
 
 export class PlanemoConfigTreeDataProvider implements TreeDataProvider<TreeItem>{
 
@@ -194,13 +195,11 @@ export class PlanemoConfigTreeDataProvider implements TreeDataProvider<TreeItem>
 
     private getGalaxyRootItem(planemoConfig: IPlanemoConfiguration): TreeItem {
         const galaxyRootPath = planemoConfig.galaxyRoot();
-        const galaxyRoot: TreeItem = {
-            label: "Root",
-            description: galaxyRootPath!,
-            tooltip: "Root of development galaxy directory to execute commands with.",
-            collapsibleState: TreeItemCollapsibleState.None,
-        };
-        return galaxyRoot;
+        const label = "Root";
+        const galaxyRootUri = Uri.file(galaxyRootPath!);
+        const tooltip = "Root of development galaxy directory to execute commands with.";
+        const item = new DirectoryTreeItem(label, galaxyRootUri, tooltip);
+        return item;
     }
 }
 

--- a/client/src/planemo/views/configurationView.ts
+++ b/client/src/planemo/views/configurationView.ts
@@ -1,0 +1,180 @@
+'use strict';
+
+import { EOL } from 'os';
+import * as path from 'path';
+import { Event, EventEmitter, ExtensionContext, ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, window } from "vscode";
+import { execAsync, readFile } from '../../utils';
+import { IConfigurationFactory, IPlanemoConfiguration } from "../configuration";
+
+const PLANEMO_LABEL = "Planemo";
+const GALAXY_LABEL = "Galaxy";
+const UNKNOWN = "Unknown";
+
+export function registerConfigTreeDataProvider(context: ExtensionContext, configFactory: IConfigurationFactory): PlanemoConfigTreeDataProvider {
+
+    const treeDataProvider = new PlanemoConfigTreeDataProvider(configFactory);
+    const treeView = window.createTreeView("planemo-config", {
+        showCollapseAll: true,
+        treeDataProvider,
+        canSelectMany: false,
+    });
+    context.subscriptions.push(treeView);
+    return treeDataProvider;
+}
+
+export class PlanemoConfigTreeItem extends TreeItem {
+
+    constructor(
+        public readonly label: string,
+        public readonly collapsibleState: TreeItemCollapsibleState = TreeItemCollapsibleState.Collapsed,
+        public getItemChildren?: (planemoConfig: IPlanemoConfiguration) => Promise<TreeItem[]>,
+    ) {
+        super(label, collapsibleState);
+    }
+
+}
+
+
+export class PlanemoConfigTreeDataProvider implements TreeDataProvider<TreeItem>{
+
+    private _onDidChangeTreeData: EventEmitter<TreeItem | undefined | void> = new EventEmitter<TreeItem | undefined | void>();
+    readonly onDidChangeTreeData: Event<TreeItem | undefined | void> = this._onDidChangeTreeData.event;
+
+    constructor(private configFactory: IConfigurationFactory) {
+    }
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: TreeItem): TreeItem {
+        return element;
+    }
+
+    async getChildren(element?: PlanemoConfigTreeItem): Promise<TreeItem[]> {
+
+        const planemoConfig = this.configFactory.getConfiguration().planemo();
+        const planemoConfigValidation = await planemoConfig.validate();
+        if (planemoConfigValidation.hasErrors()) {
+            return Promise.resolve([]);
+        }
+
+        if (element && element.getItemChildren) {
+            return Promise.resolve(await element.getItemChildren(planemoConfig));
+        } else {
+            const rootItem: PlanemoConfigTreeItem = {
+                label: PLANEMO_LABEL,
+                collapsibleState: TreeItemCollapsibleState.Collapsed,
+                description: 'configuration details',
+                contextValue: 'planemoConfigItem',
+                iconPath: {
+                    light: path.join(__filename, '..', '..', 'resources', 'light', 'planemo.svg'),
+                    dark: path.join(__filename, '..', '..', 'resources', 'dark', 'planemo.svg')
+                },
+                getItemChildren: async planemoConfig => {
+                    const version = await this.getPlanemoVersionItem(planemoConfig);
+                    const galaxy = await this.getPlanemoGalaxyItem(planemoConfig);
+
+                    return [
+                        version,
+                        galaxy,
+                    ]
+                }
+            };
+            return Promise.resolve([rootItem]);
+        }
+
+    }
+
+    private async getPlanemoVersionItem(planemoConfig: IPlanemoConfiguration): Promise<TreeItem> {
+        const planemoVersion = await this.getPlanemoVersion(planemoConfig);
+        const item: TreeItem = {
+            label: "Version",
+            collapsibleState: TreeItemCollapsibleState.None,
+            description: planemoVersion,
+            tooltip: planemoConfig.envPath()
+        };
+        return item;
+    }
+
+    private async getPlanemoVersion(planemoConfig: IPlanemoConfiguration): Promise<string> {
+        try {
+            const planemoPath = planemoConfig.envPath();
+            const getPlanemoVersionCmd = `"${planemoPath}" --version`;
+            const commandResult = await execAsync(getPlanemoVersionCmd);
+            const versionMatch = commandResult.match(new RegExp(/[\d.]+/g));
+            const version = versionMatch?.pop();
+            return version ?? UNKNOWN;
+        } catch (error) {
+            console.error(`[gls.planemo] getPlanemoVersion: ${error}`);
+            return UNKNOWN;
+        }
+    }
+
+    private async getPlanemoGalaxyItem(planemoConfig: IPlanemoConfiguration): Promise<PlanemoConfigTreeItem> {
+        const item: PlanemoConfigTreeItem = {
+            label: GALAXY_LABEL,
+            description: "instance used by Planemo",
+            collapsibleState: TreeItemCollapsibleState.Collapsed,
+            contextValue: 'galaxyConfigItem',
+            getItemChildren: async planemoConfig => {
+                const version = await this.getGalaxyVersionItem(planemoConfig);
+                const galaxyRoot = this.getGalaxyRootItem(planemoConfig);
+
+                return [
+                    version,
+                    galaxyRoot,
+                ]
+            }
+        };
+        return item;
+    }
+
+    private getGalaxyRootItem(planemoConfig: IPlanemoConfiguration): TreeItem {
+        const galaxyRootPath = planemoConfig.galaxyRoot();
+        const galaxyRoot: TreeItem = {
+            label: "Root",
+            description: galaxyRootPath!,
+            collapsibleState: TreeItemCollapsibleState.None,
+        };
+        return galaxyRoot;
+    }
+
+    private async getGalaxyVersionItem(planemoConfig: IPlanemoConfiguration): Promise<TreeItem> {
+        const version = await this.getGalaxyVersion(planemoConfig);
+        const icon = new ThemeIcon(version ? "pass" : "alert");
+        const item: TreeItem = {
+            label: "Version",
+            collapsibleState: TreeItemCollapsibleState.None,
+            description: version,
+            tooltip: `Galaxy ${version}`,
+            iconPath: icon,
+        };
+        return item;
+    }
+
+    private async getGalaxyVersion(planemoConfig: IPlanemoConfiguration): Promise<string> {
+        try {
+            const galaxyRootPath = planemoConfig.galaxyRoot();
+            const versionFilePath = path.join(galaxyRootPath!, 'lib', 'galaxy', 'version.py');
+            const content = await readFile(versionFilePath);
+            const lines = content.split(EOL);
+            let version = undefined;
+            if (lines.length > 0) {
+                const versionMatch = lines[0].match(new RegExp(/VERSION_MAJOR = "(?<version>[\d.]+)"/));
+                version = versionMatch?.groups?.version;
+            }
+            return version ?? UNKNOWN;
+        } catch (error) {
+            console.error(`[gls.planemo] getGalaxyVersion: ${error}`);
+            return UNKNOWN;
+        }
+    }
+}
+
+
+
+
+
+
+

--- a/client/src/planemo/views/main.ts
+++ b/client/src/planemo/views/main.ts
@@ -2,6 +2,7 @@
 
 import { ExtensionContext, workspace } from "vscode";
 import { LanguageClient } from "vscode-languageclient";
+import { Settings } from "../../configuration/workspaceConfiguration";
 import { IConfigurationFactory } from "../configuration";
 import { registerConfigTreeDataProvider } from "./configurationView";
 
@@ -12,8 +13,8 @@ export function registerViews(client: LanguageClient, context: ExtensionContext,
 
     context.subscriptions.push(workspace.onDidChangeConfiguration(async configurationChange => {
         const sectionsToReload = [
-            'galaxyTools.planemo.envPath',
-            'galaxyTools.planemo.galaxyRoot',
+            Settings.Planemo.ENV_PATH,
+            Settings.Planemo.GALAXY_ROOT,
         ];
 
         const needsReload = sectionsToReload.some(

--- a/client/src/planemo/views/main.ts
+++ b/client/src/planemo/views/main.ts
@@ -1,0 +1,25 @@
+'use strict';
+
+import { ExtensionContext, workspace } from "vscode";
+import { LanguageClient } from "vscode-languageclient";
+import { IConfigurationFactory } from "../configuration";
+import { registerConfigTreeDataProvider } from "./configurationView";
+
+
+export function registerViews(client: LanguageClient, context: ExtensionContext, configFactory: IConfigurationFactory) {
+
+    const configTreeDataProvider = registerConfigTreeDataProvider(context, configFactory);
+
+    context.subscriptions.push(workspace.onDidChangeConfiguration(async configurationChange => {
+        const sectionsToReload = [
+            'galaxyTools.planemo.envPath',
+            'galaxyTools.planemo.galaxyRoot',
+        ];
+
+        const needsReload = sectionsToReload.some(
+            section => configurationChange.affectsConfiguration(section));
+        if (needsReload) {
+            configTreeDataProvider.refresh();
+        }
+    }));
+}

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -41,3 +41,9 @@ export function readFile(file: fs.PathLike): Promise<string> {
         });
     });
 }
+
+export async function exists(path: string): Promise<boolean> {
+    return fs.promises.access(path, fs.constants.F_OK)
+        .then(() => true)
+        .catch(() => false);
+}

--- a/client/src/views/common.ts
+++ b/client/src/views/common.ts
@@ -1,0 +1,18 @@
+'use strict';
+
+import { TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
+
+
+export class DirectoryTreeItem extends TreeItem {
+
+    constructor(
+        public readonly label: string,
+        public readonly directoryUri: Uri,
+        public readonly tooltip?: string | undefined,
+        public readonly collapsibleState: TreeItemCollapsibleState = TreeItemCollapsibleState.None,
+    ) {
+        super(label, collapsibleState);
+        this.description = directoryUri.fsPath;
+        this.contextValue = "directoryItem";
+    }
+}


### PR DESCRIPTION
This will display some information about the currently configured `planemo` to be used by the extension. With some considerations:

### Planemo Explorer
The so-called `Planemo Explorer` will be the general panel where most of the customs views of the extension will be placed like information about the running state of a `planemo serve` command to name one. Currently, only the planemo configuration view is placed here.

### Configuration View 
If the planemo configuration is not valid, the previous `Welcome` view will be displayed with some instruction on how to configure it.

![image](https://user-images.githubusercontent.com/46503462/111911064-2ceca100-8a64-11eb-8d8b-3c010c2b7d24.png)

After the planemo binary has been set up correctly the `Welcome` view will disappear and the Configuration view will be displayed.

![image](https://user-images.githubusercontent.com/46503462/111911119-70470f80-8a64-11eb-9d9d-eadd55249cd5.png)

The information about the configuration displayed so far (planemo and galaxy versions, paths, etc.) is just a sample of what may be interesting to display here, but other suggestions are much appreciated.

This is the result of playing with the VSCode TreeView API:

![planemo-config-view](https://user-images.githubusercontent.com/46503462/111911274-2ca0d580-8a65-11eb-894b-8453611c58f0.gif)
