### PR TITLE
Improve tool validation troubleshooting with macros

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -125,6 +125,13 @@
         "category": "Galaxy Tools",
         "enablement": "galaxytools:isActive",
         "icon": "$(terminal-view-icon)"
+      },
+      {
+        "command": "galaxytools.preview.expandedDocument",
+        "title": "Open a preview of the tool document with all the macros expanded.",
+        "category": "Galaxy Tools",
+        "enablement": "galaxytools:isActive",
+        "icon": "$(open-preview)"
       }
     ],
     "keybindings": [

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,7 +1,8 @@
 'use strict';
 
-import { window, Position, SnippetString, Range, ExtensionContext, commands, TextEditor } from "vscode";
+import { window, Position, SnippetString, Range, ExtensionContext, commands, TextEditor, Uri, workspace, ViewColumn, languages } from "vscode";
 import { RequestType, TextDocumentIdentifier, TextDocumentPositionParams, LanguageClient } from "vscode-languageclient";
+import { Constants } from "./constants";
 import { cloneRange } from "./utils";
 import { DirectoryTreeItem } from "./views/common";
 
@@ -15,6 +16,8 @@ export namespace Commands {
     export const DISCOVER_TESTS = 'galaxytools.tests.discover';
     export const PLANEMO_OPEN_SETTINGS = 'galaxytools.planemo.openSettings';
     export const OPEN_TERMINAL_AT_DIRECTORY_ITEM = 'galaxytools.openTerminalAtDirectory';
+    export const GENERATE_EXPANDED_DOCUMENT = 'galaxytools.generate.expandedDocument';
+    export const PREVIEW_EXPANDED_DOCUMENT = 'galaxytools.preview.expandedDocument';
 }
 
 namespace GeneratedTestRequest {
@@ -33,6 +36,10 @@ namespace SortDocumentParamsAttrsCommandRequest {
     export const type: RequestType<TextDocumentIdentifier, Array<ReplaceTextRangeResult>, any, any> = new RequestType(Commands.SORT_DOCUMENT_PARAMS_ATTRS);
 }
 
+namespace GeneratedExpandedDocumentRequest {
+    export const type: RequestType<TextDocumentIdentifier, GeneratedExpandedDocument, any, any> = new RequestType(Commands.GENERATE_EXPANDED_DOCUMENT);
+}
+
 interface GeneratedSnippetResult {
     snippet: string;
     position: Position;
@@ -45,6 +52,10 @@ interface ReplaceTextRangeResult {
     replace_range: Range;
 }
 
+export interface GeneratedExpandedDocument {
+    content: string;
+    error_message: string;
+}
 
 
 export function setupCommands(client: LanguageClient, context: ExtensionContext) {
@@ -71,6 +82,13 @@ export function setupCommands(client: LanguageClient, context: ExtensionContext)
         requestSortDocumentParamsAttrs(client, SortDocumentParamsAttrsCommandRequest.type)
     };
     context.subscriptions.push(commands.registerCommand(Commands.SORT_DOCUMENT_PARAMS_ATTRS, sortDocumentParamsAttrs));
+
+    const generateExpandedDocument = async (uri: Uri) => {
+        return requestExpandedDocument(uri, client, GeneratedExpandedDocumentRequest.type)
+    };
+    context.subscriptions.push(commands.registerCommand(Commands.GENERATE_EXPANDED_DOCUMENT, generateExpandedDocument));
+
+    context.subscriptions.push(commands.registerCommand(Commands.PREVIEW_EXPANDED_DOCUMENT, previewExpandedDocument));
 
     // Open planemo settings
     context.subscriptions.push(commands.registerCommand(Commands.PLANEMO_OPEN_SETTINGS, openPlanemoSettings))
@@ -186,4 +204,37 @@ function openTerminalAtDirectoryItem(item: DirectoryTreeItem) {
 
 function notifyExtensionActive() {
     commands.executeCommand('setContext', 'galaxytools:isActive', true);
+}
+
+async function requestExpandedDocument(uri: Uri, client: LanguageClient, request: RequestType<TextDocumentIdentifier, GeneratedExpandedDocument, any, any>): Promise<GeneratedExpandedDocument> {
+    const fileUri = setUriScheme(uri, "file");
+    const document = await workspace.openTextDocument(fileUri)
+
+    let param = client.code2ProtocolConverter.asTextDocumentIdentifier(document);
+    let response = await client.sendRequest(request, param);
+    if (!response || response.error_message) {
+        if (response.error_message) {
+            window.showErrorMessage(response.error_message);
+        }
+        return Promise.reject();
+    }
+    return response;
+}
+
+async function previewExpandedDocument() {
+    let activeEditor = window.activeTextEditor;
+    if (!activeEditor) return;
+    const isSaved = ensureDocumentIsSaved(activeEditor);
+    if (!isSaved) return;
+
+    const document = activeEditor.document;
+    const uri = setUriScheme(document.uri, Constants.EXPAND_DOCUMENT_SCHEMA);
+    const doc = await workspace.openTextDocument(uri);
+    await window.showTextDocument(doc, { preview: false, viewColumn: ViewColumn.Beside });
+}
+
+function setUriScheme(uri: Uri, scheme: string): Uri {
+    const uriStr = uri.toString().replace(uri.scheme, scheme)
+    const resultUri = Uri.parse(uriStr);
+    return resultUri;
 }

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -206,7 +206,7 @@ function notifyExtensionActive() {
     commands.executeCommand('setContext', 'galaxytools:isActive', true);
 }
 
-async function requestExpandedDocument(uri: Uri, client: LanguageClient, request: RequestType<TextDocumentIdentifier, GeneratedExpandedDocument, any, any>): Promise<GeneratedExpandedDocument> {
+async function requestExpandedDocument(uri: Uri, client: LanguageClient, request: RequestType<TextDocumentIdentifier, GeneratedExpandedDocument, any, any>): Promise<GeneratedExpandedDocument | undefined> {
     const document = await workspace.openTextDocument(uri);
     let param = client.code2ProtocolConverter.asTextDocumentIdentifier(document);
     let response = await client.sendRequest(request, param);
@@ -214,7 +214,7 @@ async function requestExpandedDocument(uri: Uri, client: LanguageClient, request
         if (response.error_message) {
             window.showErrorMessage(response.error_message);
         }
-        return Promise.reject();
+        return undefined;
     }
     return response;
 }

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -13,6 +13,7 @@ export namespace Constants {
     export const REQUIRED_PYTHON_VERSION = "3.8+";
 
     export const EXPAND_DOCUMENT_SCHEMA = "gls-expand"
+    export const EXPAND_DOCUMENT_URI_SUFFIX = "%20%28Expanded%29"
 }
 
 export namespace DiagnosticCodes {

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -14,3 +14,7 @@ export namespace Constants {
 
     export const EXPAND_DOCUMENT_SCHEMA = "gls-expand"
 }
+
+export namespace DiagnosticCodes {
+    export const INVALID_EXPANDED_TOOL = 101
+}

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -11,4 +11,6 @@ export namespace Constants {
     export const PYTHON_UNIX = "python3";
     export const PYTHON_WIN = "python.exe";
     export const REQUIRED_PYTHON_VERSION = "3.8+";
+
+    export const EXPAND_DOCUMENT_SCHEMA = "gls-expand"
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,6 +9,7 @@ import { Constants } from './constants';
 import { setupCommands } from './commands';
 import { setupPlanemo } from "./planemo/main";
 import { DefaultConfigurationFactory } from "./planemo/configuration";
+import { setupProviders } from "./providers/setup";
 
 let client: LanguageClient;
 
@@ -53,6 +54,8 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(activateTagClosing(tagProvider));
 
   setupCommands(client, context);
+
+  setupProviders(client, context);
 
 
   client.onReady().then(() => {

--- a/client/src/providers/codeActions.ts
+++ b/client/src/providers/codeActions.ts
@@ -1,0 +1,26 @@
+import { CancellationToken, CodeAction, CodeActionContext, CodeActionKind, CodeActionProvider, Command, Diagnostic, ProviderResult, Range, Selection, TextDocument } from "vscode";
+import { Commands } from "../commands";
+import { DiagnosticCodes } from "../constants";
+
+
+export class GalaxyToolsCodeActionProvider implements CodeActionProvider {
+    public static readonly providedCodeActionKinds = [
+        CodeActionKind.Empty
+    ];
+
+    provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken): ProviderResult<(CodeAction | Command)[]> {
+
+        return context.diagnostics
+            .filter(diagnostic => diagnostic.code === DiagnosticCodes.INVALID_EXPANDED_TOOL)
+            .map(diagnostic => this.createPreviewExpandedDocumentCommand(diagnostic));
+    }
+
+    private createPreviewExpandedDocumentCommand(diagnostic: Diagnostic): CodeAction {
+        const action = new CodeAction('Preview expanded tool document...', CodeActionKind.Empty);
+        action.command = { command: Commands.PREVIEW_EXPANDED_DOCUMENT, title: 'Preview expanded tool document', tooltip: 'This will open a preview of the tool document with all the macros expanded.' };
+        action.diagnostics = [diagnostic];
+        action.isPreferred = true;
+        return action;
+    }
+
+}

--- a/client/src/providers/contentProvider.ts
+++ b/client/src/providers/contentProvider.ts
@@ -1,0 +1,13 @@
+import { commands, TextDocumentContentProvider, Uri } from "vscode";
+import { Commands, GeneratedExpandedDocument } from "../commands";
+
+export class GalaxyToolsExpadedDocumentContentProvider implements TextDocumentContentProvider {
+
+    async provideTextDocumentContent(uri: Uri): Promise<string> {
+        const result = await commands.executeCommand<GeneratedExpandedDocument>(Commands.GENERATE_EXPANDED_DOCUMENT, uri)
+        if (result === undefined) {
+            return "Can not expand the requested document."
+        }
+        return result.content;
+    }
+};

--- a/client/src/providers/contentProvider.ts
+++ b/client/src/providers/contentProvider.ts
@@ -1,13 +1,24 @@
 import { commands, TextDocumentContentProvider, Uri } from "vscode";
 import { Commands, GeneratedExpandedDocument } from "../commands";
+import { Constants } from "../constants";
+import { changeUriScheme } from "../utils";
 
 export class GalaxyToolsExpadedDocumentContentProvider implements TextDocumentContentProvider {
 
     async provideTextDocumentContent(uri: Uri): Promise<string> {
-        const result = await commands.executeCommand<GeneratedExpandedDocument>(Commands.GENERATE_EXPANDED_DOCUMENT, uri)
+
+        const finalUri = this.convertToFileUri(uri);
+        const result = await commands.executeCommand<GeneratedExpandedDocument>(Commands.GENERATE_EXPANDED_DOCUMENT, finalUri)
         if (result === undefined) {
             return "Can not expand the requested document."
         }
         return result.content;
+    }
+
+    private convertToFileUri(uri: Uri): Uri {
+        const fileUri = changeUriScheme(uri, "file");
+        const uriStr = fileUri.toString().replace(Constants.EXPAND_DOCUMENT_URI_SUFFIX, "")
+        const finalUri = Uri.parse(uriStr);
+        return finalUri;
     }
 };

--- a/client/src/providers/setup.ts
+++ b/client/src/providers/setup.ts
@@ -1,0 +1,21 @@
+import { ExtensionContext, languages, workspace } from "vscode";
+import { LanguageClient } from "vscode-languageclient";
+import { Constants } from "../constants";
+import { GalaxyToolsCodeActionProvider } from "./codeActions";
+import { GalaxyToolsExpadedDocumentContentProvider } from "./contentProvider";
+
+export function setupProviders(client: LanguageClient, context: ExtensionContext) {
+
+    const codeActionProvider = new GalaxyToolsCodeActionProvider();
+    context.subscriptions.push(
+        languages.registerCodeActionsProvider(Constants.LANGUAGE_ID, codeActionProvider, {
+            providedCodeActionKinds: GalaxyToolsCodeActionProvider.providedCodeActionKinds
+        })
+    );
+
+    const expandedDocumentProvider = new GalaxyToolsExpadedDocumentContentProvider();
+    context.subscriptions.push(
+        workspace.registerTextDocumentContentProvider(Constants.EXPAND_DOCUMENT_SCHEMA, expandedDocumentProvider)
+    );
+
+}

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs';
 import { exec } from "child_process";
-import { Position, Range } from "vscode";
+import { Position, Range, Uri } from "vscode";
 
 
 export async function execAsync(command: string, options: object = {}): Promise<string> {
@@ -46,4 +46,13 @@ export async function exists(path: string): Promise<boolean> {
     return fs.promises.access(path, fs.constants.F_OK)
         .then(() => true)
         .catch(() => false);
+}
+
+export function changeUriScheme(uri: Uri, scheme: string): Uri {
+    if (uri.scheme === scheme) {
+        return uri;
+    }
+    const uriStr = uri.toString().replace(uri.scheme, scheme)
+    const resultUri = Uri.parse(uriStr);
+    return resultUri;
 }

--- a/server/galaxyls/constants.py
+++ b/server/galaxyls/constants.py
@@ -10,6 +10,7 @@ class Commands:
     SORT_SINGLE_PARAM_ATTRS = "galaxytools.sort.singleParamAttributes"
     SORT_DOCUMENT_PARAMS_ATTRS = "galaxytools.sort.documentParamsAttributes"
     DISCOVER_TESTS = "galaxytools.tests.discover"
+    GENERATE_EXPANDED_DOCUMENT = "galaxytools.generate.expandedDocument"
 
 
 class DiagnosticCodes:

--- a/server/galaxyls/constants.py
+++ b/server/galaxyls/constants.py
@@ -1,0 +1,13 @@
+"""This module contains definitions for constants used by the Galaxy Tools Language Server."""
+
+SERVER_NAME = "Galaxy Tools LS"
+
+
+class Commands:
+    AUTO_CLOSE_TAGS = "galaxytools.completion.autoCloseTags"
+    GENERATE_TESTS = "galaxytools.generate.tests"
+    GENERATE_COMMAND = "galaxytools.generate.command"
+    SORT_SINGLE_PARAM_ATTRS = "galaxytools.sort.singleParamAttributes"
+    SORT_DOCUMENT_PARAMS_ATTRS = "galaxytools.sort.documentParamsAttributes"
+    DISCOVER_TESTS = "galaxytools.tests.discover"
+

--- a/server/galaxyls/constants.py
+++ b/server/galaxyls/constants.py
@@ -11,3 +11,6 @@ class Commands:
     SORT_DOCUMENT_PARAMS_ATTRS = "galaxytools.sort.documentParamsAttributes"
     DISCOVER_TESTS = "galaxytools.tests.discover"
 
+
+class DiagnosticCodes:
+    INVALID_EXPANDED_TOOL = 101

--- a/server/galaxyls/features.py
+++ b/server/galaxyls/features.py
@@ -1,9 +1,0 @@
-"""This module contains definitions for custom features supported
-   by the Galaxy Tools Language Server."""
-
-AUTO_CLOSE_TAGS = "galaxytools.completion.autoCloseTags"
-CMD_GENERATE_TEST = "galaxytools.generate.tests"
-CMD_GENERATE_COMMAND = "galaxytools.generate.command"
-SORT_SINGLE_PARAM_ATTRS = "galaxytools.sort.singleParamAttributes"
-SORT_DOCUMENT_PARAMS_ATTRS = "galaxytools.sort.documentParamsAttributes"
-DISCOVER_TESTS = "galaxytools.tests.discover"

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -13,8 +13,6 @@ from pygls.lsp.methods import (
     TEXT_DOCUMENT_DID_SAVE,
     WORKSPACE_DID_CHANGE_CONFIGURATION,
 )
-from pygls.lsp.types.language_features.completion import CompletionOptions
-from pygls.server import LanguageServer
 from pygls.lsp.types import (
     CompletionList,
     CompletionParams,
@@ -33,25 +31,17 @@ from pygls.lsp.types import (
     TextDocumentPositionParams,
     TextEdit,
 )
+from pygls.lsp.types.language_features.completion import CompletionOptions
+from pygls.server import LanguageServer
 from pygls.workspace import Document
 
+from galaxyls.config import CompletionMode, GalaxyToolsConfiguration
+from galaxyls.constants import Commands, SERVER_NAME
+from galaxyls.services.language import GalaxyToolLanguageService
 from galaxyls.services.validation import DocumentValidator
-
-from .config import CompletionMode, GalaxyToolsConfiguration
-from .features import (
-    AUTO_CLOSE_TAGS,
-    CMD_GENERATE_COMMAND,
-    CMD_GENERATE_TEST,
-    DISCOVER_TESTS,
-    SORT_DOCUMENT_PARAMS_ATTRS,
-    SORT_SINGLE_PARAM_ATTRS,
-)
-from .services.language import GalaxyToolLanguageService
-from .services.xml.document import XmlDocument
-from .services.xml.parser import XmlDocumentParser
-from .types import AutoCloseTagResult, GeneratedSnippetResult, ReplaceTextRangeResult, TestSuiteInfoResult
-
-SERVER_NAME = "Galaxy Tools LS"
+from galaxyls.services.xml.document import XmlDocument
+from galaxyls.services.xml.parser import XmlDocumentParser
+from galaxyls.types import AutoCloseTagResult, GeneratedSnippetResult, ReplaceTextRangeResult, TestSuiteInfoResult
 
 
 class GalaxyToolsLanguageServer(LanguageServer):
@@ -106,7 +96,7 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
         return server.service.get_completion(xml_document, params, server.configuration.completion.mode)
 
 
-@language_server.feature(AUTO_CLOSE_TAGS)
+@language_server.feature(Commands.AUTO_CLOSE_TAGS)
 def auto_close_tag(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[AutoCloseTagResult]:
     """Responds to a close tag request to close the currently opened node."""
     if server.configuration.completion.auto_close_tags:
@@ -152,7 +142,7 @@ def did_close(server: GalaxyToolsLanguageServer, params: DidCloseTextDocumentPar
     # server.show_message("Xml Document Closed")
 
 
-@language_server.feature(CMD_GENERATE_TEST)
+@language_server.feature(Commands.GENERATE_TESTS)
 async def cmd_generate_test(
     server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier
 ) -> Optional[GeneratedSnippetResult]:
@@ -162,7 +152,7 @@ async def cmd_generate_test(
         return server.service.generate_tests(document)
 
 
-@language_server.feature(CMD_GENERATE_COMMAND)
+@language_server.feature(Commands.GENERATE_COMMAND)
 async def cmd_generate_command(
     server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier
 ) -> Optional[GeneratedSnippetResult]:
@@ -172,7 +162,7 @@ async def cmd_generate_command(
         return server.service.generate_command(document)
 
 
-@language_server.feature(SORT_SINGLE_PARAM_ATTRS)
+@language_server.feature(Commands.SORT_SINGLE_PARAM_ATTRS)
 def sort_single_param_attrs_command(
     server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams
 ) -> Optional[ReplaceTextRangeResult]:
@@ -183,7 +173,7 @@ def sort_single_param_attrs_command(
         return server.service.sort_single_param_attrs(xml_document, params)
 
 
-@language_server.feature(SORT_DOCUMENT_PARAMS_ATTRS)
+@language_server.feature(Commands.SORT_DOCUMENT_PARAMS_ATTRS)
 def sort_document_params_attrs_command(
     server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier
 ) -> Optional[List[ReplaceTextRangeResult]]:
@@ -194,7 +184,7 @@ def sort_document_params_attrs_command(
         return server.service.sort_document_param_attributes(xml_document)
 
 
-@language_server.feature(DISCOVER_TESTS)
+@language_server.feature(Commands.DISCOVER_TESTS)
 def discover_tests_command(server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier) -> List[TestSuiteInfoResult]:
     """Sorts the attributes of all the param elements contained in the document."""
     return server.service.discover_tests(server.workspace)

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -41,7 +41,13 @@ from galaxyls.services.language import GalaxyToolLanguageService
 from galaxyls.services.validation import DocumentValidator
 from galaxyls.services.xml.document import XmlDocument
 from galaxyls.services.xml.parser import XmlDocumentParser
-from galaxyls.types import AutoCloseTagResult, GeneratedSnippetResult, ReplaceTextRangeResult, TestSuiteInfoResult
+from galaxyls.types import (
+    AutoCloseTagResult,
+    GeneratedExpandedDocument,
+    GeneratedSnippetResult,
+    ReplaceTextRangeResult,
+    TestSuiteInfoResult,
+)
 
 
 class GalaxyToolsLanguageServer(LanguageServer):
@@ -184,6 +190,16 @@ def sort_document_params_attrs_command(
         return server.service.sort_document_param_attributes(xml_document)
 
 
+@language_server.feature(Commands.GENERATE_EXPANDED_DOCUMENT)
+def generate_expanded_command(
+    server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier
+) -> Optional[GeneratedExpandedDocument]:
+    """Generates a expanded version (with all macros replaced) of the tool document."""
+    document = server.workspace.get_document(params.uri)
+    if document and DocumentValidator.is_tool_document(document):
+        return server.service.macro_expander.generate_expanded_from(document.path)
+
+
 @language_server.feature(Commands.DISCOVER_TESTS)
 def discover_tests_command(server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier) -> List[TestSuiteInfoResult]:
     """Sorts the attributes of all the param elements contained in the document."""
@@ -222,4 +238,4 @@ def _get_xml_document(document: Document) -> XmlDocument:
 
 def _is_document_supported(document: Document) -> bool:
     """Returns True if the given document is supported by the server."""
-    return DocumentValidator().has_valid_root(document)
+    return DocumentValidator.has_valid_root(document)

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -198,6 +198,7 @@ def generate_expanded_command(
     document = server.workspace.get_document(params.uri)
     if document and DocumentValidator.is_tool_document(document):
         return server.service.macro_expander.generate_expanded_from(document.path)
+    return GeneratedExpandedDocument(error_message=f"The document {document.filename} is not a valid Galaxy Tool wrapper.")
 
 
 @language_server.feature(Commands.DISCOVER_TESTS)

--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -102,7 +102,7 @@ class XmlCompletionService:
         return CompletionList(items=result, is_incomplete=False)
 
     def get_attribute_value_completion(self, context: XmlContext) -> CompletionList:
-        """Gets a list of possible values for a anumeration restricted attribute if exists.
+        """Gets a list of possible values for an enumeration restricted attribute if exists.
 
         Args:
             context (XmlContext): The XML context at an attribute value position.

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from galaxyls.services.definitions import DocumentDefinitionsProvider
+from galaxyls.services.macros import MacroExpanderService
 from galaxyls.services.tools.common import TestsDiscoveryService, ToolParamAttributeSorter
 from galaxyls.services.tools.document import GalaxyToolXmlDocument
 from galaxyls.services.tools.generators.command import GalaxyToolCommandSnippetGenerator
@@ -47,13 +48,14 @@ class GalaxyToolLanguageService:
         self.xml_context_service = XmlContextService(tree)
         self.sort_service: ToolParamAttributeSorter = IUCToolParamAttributeSorter()
         self.test_discovery_service: TestsDiscoveryService = ToolTestsDiscoveryService()
+        self.macro_expander = MacroExpanderService()
 
     def set_workspace(self, workspace: Workspace):
         self.definitions_provider = DocumentDefinitionsProvider(MacroDefinitionsProvider(workspace))
 
     def get_diagnostics(self, xml_document: XmlDocument) -> List[Diagnostic]:
         """Validates the Galaxy tool XML document and returns a list
-        of diagnotics if there are any problems.
+        of diagnostics if there are any problems.
         """
         return self.xsd_service.validate_document(xml_document)
 

--- a/server/galaxyls/services/macros.py
+++ b/server/galaxyls/services/macros.py
@@ -1,0 +1,37 @@
+from typing import cast
+
+from galaxy.util import xml_macros
+from galaxyls.types import GeneratedExpandedDocument
+from lxml import etree
+
+
+def remove_macros(xml_tree: etree._ElementTree) -> etree._ElementTree:
+    """Removes the macros section from the tool tree.
+
+    Args:
+        xml_tree (etree._ElementTree): The tool element tree.
+
+    Returns:
+        etree.ElementTree: The tool element tree without the macros section.
+    """
+    to_remove = []
+    for macros_el in xml_tree.getroot().findall("macros"):
+        to_remove.append(macros_el)
+    for macros_el in to_remove:
+        xml_tree.getroot().remove(macros_el)
+    return xml_tree
+
+
+class MacroExpanderService:
+    def generate_expanded_from(self, tool_path: str) -> GeneratedExpandedDocument:
+        result = GeneratedExpandedDocument()
+        try:
+            expanded_tool_tree, _ = xml_macros.load_with_references(tool_path)
+            expanded_xml = remove_macros(expanded_tool_tree)
+            root = expanded_xml.getroot()
+            etree.indent(root, space=" " * 4)
+            content = cast(str, etree.tostring(root, pretty_print=True, encoding=str))
+            result.content = content
+        except BaseException as e:
+            result.error_message = f"{e}"
+        return result

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -77,7 +77,7 @@ class GalaxyToolXmlDocument:
             Optional[Range]: The Range of the content block.
         """
         if element:
-        return self.xml_document.get_content_range(element)
+            return self.xml_document.get_content_range(element)
 
     def get_position_before(self, element: XmlElement) -> Position:
         """Returns the document position right before the given element opening tag.
@@ -147,6 +147,23 @@ class GalaxyToolXmlDocument:
                     file_uri = path.as_uri()
                     result[filename] = file_uri
         return result
+
+    def get_macros_range(self) -> Optional[Range]:
+        """Returns the Range position of the macros element name if it exists."""
+        element = self.get_macros_element()
+        if element:
+            range = self.xml_document.get_element_name_range(element)
+            return range
+
+    def get_import_macro_file_range(self, file_path: Optional[str]) -> Optional[Range]:
+        """Returns the Range position of the imported macro file element if it exists."""
+        if file_path:
+            filename = Path(file_path).name
+            import_elements = self.get_macro_import_elements()
+            for imp in import_elements:
+                imp_filename = imp.get_content(self.xml_document.document.source)
+                if imp_filename == filename:
+                    return self.xml_document.get_full_range(imp)
 
     def get_tool_id(self) -> Optional[str]:
         """Gets the identifier of the tool"""

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -3,7 +3,7 @@ from typing import List, Optional, cast
 from anytree import find
 from pygls.lsp.types import Position, Range
 from pygls.workspace import Document
-from galaxyls.services.tools.constants import INPUTS, OUTPUTS, TESTS, TOOL
+from galaxyls.services.tools.constants import INPUTS, MACROS, OUTPUTS, TESTS, TOOL
 from galaxyls.services.tools.inputs import GalaxyToolInputTree
 from galaxyls.services.xml.nodes import XmlContainerNode, XmlElement
 
@@ -124,9 +124,17 @@ class GalaxyToolXmlDocument:
             return outputs.elements
         return []
 
+    def get_tool_element(self) -> Optional[XmlElement]:
+        """Gets the root tool element"""
+        return self.find_element(TOOL)
+
+    def get_macros_element(self) -> Optional[XmlElement]:
+        """Gets the macros element"""
+        return self.find_element(MACROS)
+
     def get_tool_id(self) -> Optional[str]:
         """Gets the identifier of the tool"""
-        tool_element = self.find_element(TOOL)
+        tool_element = self.get_tool_element()
         return tool_element.get_attribute("id")
 
     def get_tests(self) -> List[XmlElement]:
@@ -139,3 +147,7 @@ class GalaxyToolXmlDocument:
         if tests:
             return tests.elements
         return []
+
+    @classmethod
+    def from_xml_document(cls, xml_document: XmlDocument) -> "GalaxyToolXmlDocument":
+        return GalaxyToolXmlDocument(xml_document.document, xml_document)

--- a/server/galaxyls/services/tools/generators/snippets.py
+++ b/server/galaxyls/services/tools/generators/snippets.py
@@ -15,8 +15,8 @@ class SnippetGenerator(ABC):
     snippets using the information of the tool document."""
 
     def __init__(self, tool_document: GalaxyToolXmlDocument, tabSize: int = 4) -> None:
-        self.tool_document: GalaxyToolXmlDocument = tool_document
-        self.expanded_document: GalaxyToolXmlDocument = self._get_expanded_tool_document(tool_document)
+        self.tool_document = tool_document
+        self.expanded_document = self._get_expanded_tool_document(tool_document)
         self.tabstop_count: int = 0
         self.indent_spaces: str = " " * tabSize
         super().__init__()

--- a/server/galaxyls/services/tools/testing.py
+++ b/server/galaxyls/services/tools/testing.py
@@ -24,7 +24,7 @@ class ToolTestsDiscoveryService(TestsDiscoveryService):
 
     def _get_test_suite_from_document(self, document: Document) -> Optional[TestSuiteInfoResult]:
         xml_document = XmlDocumentParser().parse(document)
-        tool = GalaxyToolXmlDocument(xml_document.document, xml_document)
+        tool = GalaxyToolXmlDocument.from_xml_document(xml_document)
         tool_id = tool.get_tool_id()
         if tool_id:
             tests = tool.get_tests()

--- a/server/galaxyls/services/validation.py
+++ b/server/galaxyls/services/validation.py
@@ -13,24 +13,27 @@ TAG_REGEX = rf"[\n\s]*?.*?[\n\s]*?<(?!\?)(?P<{TAG_GROUP_NAME}>[\w]*)"
 class DocumentValidator:
     """Provides some utilities to quickly check documents without completely parse them beforehand."""
 
-    def has_valid_root(self, document: Document) -> bool:
+    @classmethod
+    def has_valid_root(cls, document: Document) -> bool:
         """Checks if the document's root element matches one of the supported types."""
-        root = self._get_document_root_tag(document)
+        root = DocumentValidator._get_document_root_tag(document)
         if root is not None:
             root_tag = root.upper()
             supported = [e.name for e in DocumentType if e != DocumentType.UNKNOWN]
             return root_tag in supported
         return False
 
-    def is_tool_document(self, document: Document) -> bool:
+    @classmethod
+    def is_tool_document(cls, document: Document) -> bool:
         """Checks if the document's root element is <tool>."""
-        root = self._get_document_root_tag(document)
+        root = DocumentValidator._get_document_root_tag(document)
         if root is not None:
             root_tag = root.upper()
             return root_tag == DocumentType.TOOL.name
         return False
 
-    def _get_document_root_tag(self, document: Document) -> Optional[str]:
+    @classmethod
+    def _get_document_root_tag(cls, document: Document) -> Optional[str]:
         """Checks the first MAX_PEEK_CONTENT characters of the document for a root tag and
         returns the name of the tag if found."""
         content_peek = document.source[:MAX_PEEK_CONTENT]

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -76,6 +76,11 @@ class XmlDocument(XmlSyntaxNode):
         """Indicates if the document is a macro definition file."""
         return self.document_type == DocumentType.MACROS
 
+    @property
+    def is_tool_file(self) -> bool:
+        """Indicates if the document is a tool definition file."""
+        return self.document_type == DocumentType.TOOL
+
     def get_node_at(self, offset: int) -> Optional[XmlSyntaxNode]:
         """Gets the syntax node a the given offset."""
         return self.root.find_node_at(offset)

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -114,6 +114,19 @@ class XmlDocument(XmlSyntaxNode):
             return None
         return convert_document_offsets_to_range(self.document, start_offset, end_offset)
 
+    def get_full_range(self, node: XmlSyntaxNode) -> Optional[Range]:
+        """Gets the Range positions for the given XML node in the document.
+
+        Args:
+            node (XmlSyntaxNode): The XML node to determine it's range positions.
+
+        Returns:
+            Optional[Range]: The range positions for the entire node.
+        """
+        if node.start < 0 or node.end < 0:
+            return None
+        return convert_document_offsets_to_range(self.document, node.start, node.end)
+
     def get_position_before(self, element: XmlElement) -> Position:
         """Return the position in the document before the given element.
 

--- a/server/galaxyls/services/xml/nodes.py
+++ b/server/galaxyls/services/xml/nodes.py
@@ -7,7 +7,7 @@ from galaxyls.services.xml.types import NodeType
 
 
 class XmlSyntaxNode(ABC, NodeMixin):
-    """Abtract base class that represents a syntax node in the syntax tree."""
+    """Abstract base class that represents a syntax node in the syntax tree."""
 
     def __init__(self):
         self.name: Optional[str] = None

--- a/server/galaxyls/services/xsd/service.py
+++ b/server/galaxyls/services/xsd/service.py
@@ -33,7 +33,7 @@ class GalaxyToolXsdService:
 
     def validate_document(self, xml_document: XmlDocument) -> List[Diagnostic]:
         """Validates the Galaxy tool xml using the XSD schema and returns a list
-        of diagnotics if there are any problems.
+        of diagnostics if there are any problems.
         """
         return self.validator.validate_document(xml_document)
 

--- a/server/galaxyls/services/xsd/validation.py
+++ b/server/galaxyls/services/xsd/validation.py
@@ -14,6 +14,8 @@ from galaxyls.services.macros import remove_macros
 from galaxyls.services.tools.document import GalaxyToolXmlDocument
 from galaxyls.services.xml.document import XmlDocument
 
+EXPAND_DOCUMENT_URI_SUFFIX = "%20%28Expanded%29"
+
 
 class GalaxyToolValidationService:
     """Service providing diagnostics for errors in the XML validation."""
@@ -192,11 +194,12 @@ class GalaxyToolValidationService:
                 related_information=[
                     DiagnosticRelatedInformation(
                         message=(
-                            "The validation error ocurred on the expanded version of the document, i.e. after replacing macros. "
+                            "The validation error ocurred on the expanded version of "
+                            "the document, i.e. after replacing macros. "
                             "Click here to preview the expanded document."
                         ),
                         location=Location(
-                            uri=virtual_uri,
+                            uri=f"{virtual_uri}{EXPAND_DOCUMENT_URI_SUFFIX}",
                             range=Range(
                                 start=Position(line=error.line, character=error.column),
                                 end=Position(line=error.line, character=error.column),

--- a/server/galaxyls/services/xsd/validation.py
+++ b/server/galaxyls/services/xsd/validation.py
@@ -3,14 +3,14 @@
 
 from typing import List, Optional
 
-from galaxy.util import xml_macros
 from lxml import etree
 from pygls.lsp.types import Diagnostic, Position, Range
 from pygls.workspace import Document
 
+from galaxy.util import xml_macros
+from galaxyls.constants import DiagnosticCodes
 from galaxyls.services.tools.document import GalaxyToolXmlDocument
-
-from ..xml.document import XmlDocument
+from galaxyls.services.xml.document import XmlDocument
 
 
 class GalaxyToolValidationService:
@@ -86,6 +86,7 @@ class GalaxyToolValidationService:
                     range=tool.get_macros_range(),
                     message=f"Validation error on expanded document (after replacing macros): {error.message}",
                     source=self.server_name,
+                    code=DiagnosticCodes.INVALID_EXPANDED_TOOL,
                 )
                 for error in e.error_log.filter_from_errors()
             ]

--- a/server/galaxyls/types.py
+++ b/server/galaxyls/types.py
@@ -2,6 +2,7 @@
 """
 
 from typing import List, Optional
+from pydantic.main import BaseModel
 from pygls.lsp.types import Position, Range
 
 
@@ -82,3 +83,10 @@ class TestSuiteInfoResult:
 
         self.errored: bool = False
         self.message: Optional[str] = None
+
+
+class GeneratedExpandedDocument(BaseModel):
+    """Represents a tool document with all the macros expanded."""
+
+    content: Optional[str]
+    error_message: Optional[str]


### PR DESCRIPTION
When a tool document containing macros was validated, the reported errors in the problems tab were a bit 'vague', and a simple 'Validation error on macro...' message was displayed, which wasn't very helpful in determining the exact problem.

This was because the validation was performed in the `expanded` version of the document, so there wasn't an easy way of providing a specific line in the document where the problem was caused as both documents had quite different contents.

To help to identify and locate the real problem when the tool document is not valid after expanding all the macros and tokens, a _new feature_ was introduced that allows **previewing, as a virtual document, the contents of the expanded tool XML**. With this, we can now reference the exact line in the expanded document where the problem was found and directly navigate to it so we can better understand what is causing the validation problem and fix it more easily.

![macro-expanded](https://user-images.githubusercontent.com/46503462/114364991-458b3b00-9b7a-11eb-91ee-c841df3d5f91.gif)

This PR also contains some improvements detecting the exact imported macro file that may contain syntax errors and quickly navigate to it.

![image](https://user-images.githubusercontent.com/46503462/114366060-5d16f380-9b7b-11eb-9f41-95cfecd168c1.png)


xref #44