### PR TITLE
Auto-complete macro names

### DIFF
--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -102,16 +102,6 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
         return server.service.get_completion(xml_document, params, server.configuration.completion.mode)
 
 
-@language_server.feature(Commands.AUTO_CLOSE_TAGS)
-def auto_close_tag(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[AutoCloseTagResult]:
-    """Responds to a close tag request to close the currently opened node."""
-    if server.configuration.completion.auto_close_tags:
-        document = _get_valid_document(server, params.text_document.uri)
-        if document:
-            xml_document = _get_xml_document(document)
-            return server.service.get_auto_close_tag(xml_document, params)
-
-
 @language_server.feature(HOVER)
 def hover(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[Hover]:
     """Displays Markdown documentation for the element under the cursor."""
@@ -148,6 +138,25 @@ def did_close(server: GalaxyToolsLanguageServer, params: DidCloseTextDocumentPar
     # server.show_message("Xml Document Closed")
 
 
+@language_server.feature(DEFINITION)
+def definition(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[List[Location]]:
+    """Provides the location of a symbol definition."""
+    document = _get_valid_document(server, params.text_document.uri)
+    if document:
+        xml_document = _get_xml_document(document)
+        return server.service.definitions_provider.go_to_definition(xml_document, params.position)
+
+
+@language_server.feature(Commands.AUTO_CLOSE_TAGS)
+def auto_close_tag(server: GalaxyToolsLanguageServer, params) -> Optional[AutoCloseTagResult]:
+    """Responds to a close tag request to close the currently opened node."""
+    if server.configuration.completion.auto_close_tags:
+        document = _get_valid_document(server, params.textDocument.uri)
+        if document:
+            xml_document = _get_xml_document(document)
+            return server.service.get_auto_close_tag(xml_document, params)
+
+
 @language_server.feature(Commands.GENERATE_TESTS)
 async def cmd_generate_test(
     server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier
@@ -169,11 +178,9 @@ async def cmd_generate_command(
 
 
 @language_server.feature(Commands.SORT_SINGLE_PARAM_ATTRS)
-def sort_single_param_attrs_command(
-    server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams
-) -> Optional[ReplaceTextRangeResult]:
+def sort_single_param_attrs_command(server: GalaxyToolsLanguageServer, params) -> Optional[ReplaceTextRangeResult]:
     """Sorts the attributes of the param element under the cursor."""
-    document = _get_valid_document(server, params.text_document.uri)
+    document = _get_valid_document(server, params.textDocument.uri)
     if document:
         xml_document = _get_xml_document(document)
         return server.service.sort_single_param_attrs(xml_document, params)
@@ -205,15 +212,6 @@ def generate_expanded_command(
 def discover_tests_command(server: GalaxyToolsLanguageServer, params: TextDocumentIdentifier) -> List[TestSuiteInfoResult]:
     """Sorts the attributes of all the param elements contained in the document."""
     return server.service.discover_tests(server.workspace)
-
-
-@language_server.feature(DEFINITION)
-def definition(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[List[Location]]:
-    """Provides the location of a symbol definition."""
-    document = _get_valid_document(server, params.text_document.uri)
-    if document:
-        xml_document = _get_xml_document(document)
-        return server.service.definitions_provider.go_to_definition(xml_document, params.position)
 
 
 def _validate(server: GalaxyToolsLanguageServer, params) -> None:

--- a/server/galaxyls/services/context.py
+++ b/server/galaxyls/services/context.py
@@ -23,12 +23,14 @@ class XmlContext:
 
     def __init__(
         self,
+        xml_document: XmlDocument,
         xsd_node: Optional[XsdNode],
         node: Optional[XmlSyntaxNode] = None,
         line_text: str = "",
         position: Optional[Position] = None,
         offset: int = UNDEFINED_OFFSET,
     ):
+        self.xml_document = xml_document
         self._xsd_node = xsd_node
         self._node = node
         self._line_text = line_text
@@ -171,11 +173,11 @@ class XmlContextService:
         offset = xml_document.document.offset_at_position(position)
 
         if xml_document.is_empty:
-            return XmlContext(self.xsd_tree.root, node=None)
+            return XmlContext(xml_document, self.xsd_tree.root, node=None)
         node = xml_document.get_node_at(offset)
         xsd_node = self.find_matching_xsd_element(node, self.xsd_tree)
         line_text = xml_document.document.lines[position.line]
-        context = XmlContext(xsd_node, node, line_text, position, offset)
+        context = XmlContext(xml_document, xsd_node, node, line_text, position, offset)
         return context
 
     def find_matching_xsd_element(self, node: Optional[XmlSyntaxNode], xsd_tree: XsdTree) -> Optional[XsdNode]:

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -43,15 +43,15 @@ class GalaxyToolLanguageService:
     def __init__(self, server_name: str):
         self.xsd_service = GalaxyToolXsdService(server_name)
         self.format_service = GalaxyToolFormatService()
-        tree = self.xsd_service.xsd_parser.get_tree()
-        self.completion_service = XmlCompletionService(tree)
-        self.xml_context_service = XmlContextService(tree)
+        self.xsd_tree = self.xsd_service.xsd_parser.get_tree()
+        self.xml_context_service = XmlContextService(self.xsd_tree)
         self.sort_service: ToolParamAttributeSorter = IUCToolParamAttributeSorter()
         self.test_discovery_service: TestsDiscoveryService = ToolTestsDiscoveryService()
         self.macro_expander = MacroExpanderService()
 
     def set_workspace(self, workspace: Workspace):
         self.definitions_provider = DocumentDefinitionsProvider(MacroDefinitionsProvider(workspace))
+        self.completion_service = XmlCompletionService(self.xsd_tree, self.definitions_provider)
 
     def get_diagnostics(self, xml_document: XmlDocument) -> List[Diagnostic]:
         """Validates the Galaxy tool XML document and returns a list

--- a/server/galaxyls/services/tools/macros.py
+++ b/server/galaxyls/services/tools/macros.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from pydantic import BaseModel
 from pygls.lsp.types import Location
@@ -80,6 +80,14 @@ class MacroDefinitionsProvider:
             tokens=tokens,
             macros=macros,
         )
+
+    def get_macro_names(self, tool_xml: XmlDocument) -> Set[str]:
+        tool = GalaxyToolXmlDocument.from_xml_document(tool_xml)
+        macros = self._get_macro_definitions(tool_xml)
+        imported_macro_files = self._get_imported_macro_files_from_tool(tool)
+        for file in imported_macro_files.values():
+            macros.update(file.macros)
+        return set(macros.keys())
 
     def _get_imported_macro_files_from_tool(self, tool: GalaxyToolXmlDocument) -> Dict[str, ImportedMacrosFile]:
         macro_files = {}

--- a/server/galaxyls/tests/integration/test_completion.py
+++ b/server/galaxyls/tests/integration/test_completion.py
@@ -1,0 +1,77 @@
+import pytest
+
+from typing import List
+from pytest_mock import MockerFixture
+
+from pygls.lsp.types import CompletionContext, CompletionTriggerKind
+from galaxyls.services.completion import XmlCompletionService
+from galaxyls.services.context import XmlContextService
+from galaxyls.services.definitions import DocumentDefinitionsProvider
+from galaxyls.services.tools.macros import MacroDefinitionsProvider
+from galaxyls.services.xsd.service import GalaxyToolXsdService
+from galaxyls.services.xsd.types import XsdTree
+from galaxyls.tests.unit.utils import TestUtils
+
+
+@pytest.fixture()
+def galaxy_xsd_tree() -> XsdTree:
+    xsd_service = GalaxyToolXsdService("Integration Tests")
+    tree = xsd_service.xsd_parser.get_tree()
+    return tree
+
+
+class TestIntegrationXmlCompletionServiceClass:
+    @pytest.mark.parametrize(
+        "source_with_mark, expected_item_names",
+        [
+            (
+                """
+                <tool id="tool" name="tool">
+                    <macros>
+                        <xml name="macro_1">
+                            <param name="input1" />
+                        </xml>
+                    </macros>
+                    <inputs>
+                        <expand macro="^"/>
+                    </inputs>
+                </tool>
+                """,
+                ["macro_1"],
+            ),
+            (
+                """
+                <tool id="tool" name="tool">
+                    <macros>
+                        <xml name="macro_1"><param name="input1"/></xml>
+                        <macro name="macro_2"><param name="input2"/></macro>
+                    </macros>
+                    <inputs>
+                        <expand macro="^"/>
+                    </inputs>
+                </tool>
+                """,
+                ["macro_1", "macro_2"],
+            ),
+        ],
+    )
+    def test_completion_on_macro_attribute_returns_expected(
+        self,
+        galaxy_xsd_tree: XsdTree,
+        source_with_mark: str,
+        expected_item_names: List[str],
+        mocker: MockerFixture,
+    ):
+        position, source_without_mark = TestUtils.extract_mark_from_source("^", source_with_mark)
+        document = TestUtils.from_source_to_xml_document(source_without_mark)
+        service = XmlContextService(galaxy_xsd_tree)
+        context = service.get_xml_context(document, position)
+        fake_completion_context = CompletionContext(trigger_kind=CompletionTriggerKind.Invoked)
+        workspace = mocker.Mock()
+        definitions_provider = DocumentDefinitionsProvider(MacroDefinitionsProvider(workspace))
+        service = XmlCompletionService(galaxy_xsd_tree, definitions_provider)
+
+        completion_result = service.get_completion_at_context(context, fake_completion_context)
+
+        assert completion_result
+        assert sorted([item.label for item in completion_result.items]) == sorted(expected_item_names)

--- a/server/galaxyls/tests/unit/test_completion.py
+++ b/server/galaxyls/tests/unit/test_completion.py
@@ -4,6 +4,8 @@ import pytest
 from pytest_mock import MockerFixture
 
 from galaxyls.services.context import XmlContextService
+from galaxyls.services.definitions import DocumentDefinitionsProvider
+from galaxyls.services.xml.document import XmlDocument
 
 from ...services.completion import (
     AutoCloseTagResult,
@@ -34,6 +36,16 @@ def fake_tree(mocker: MockerFixture) -> XsdTree:
 
 
 @pytest.fixture()
+def fake_xml_doc(mocker: MockerFixture) -> XmlDocument:
+    return mocker.Mock(XmlDocument)
+
+
+@pytest.fixture()
+def fake_definitions_provider(mocker: MockerFixture) -> DocumentDefinitionsProvider:
+    return mocker.Mock(DocumentDefinitionsProvider)
+
+
+@pytest.fixture()
 def fake_tree_with_attrs(mocker: MockerFixture) -> XsdTree:
     fake_root = XsdNode("root", element=mocker.Mock())
     fake_attr = XsdAttribute("one", element=mocker.Mock())
@@ -47,18 +59,18 @@ def fake_tree_with_attrs(mocker: MockerFixture) -> XsdTree:
 
 
 @pytest.fixture()
-def fake_empty_context(fake_tree: XsdTree) -> XmlContext:
-    fake_context = XmlContext(fake_tree.root)
+def fake_empty_context(fake_tree: XsdTree, fake_xml_doc: XmlDocument) -> XmlContext:
+    fake_context = XmlContext(fake_xml_doc, fake_tree.root)
     return fake_context
 
 
 @pytest.fixture()
-def fake_context_on_root_node(fake_tree: XsdTree) -> XmlContext:
+def fake_context_on_root_node(fake_tree: XsdTree, fake_xml_doc: XmlDocument) -> XmlContext:
     fake_node = XmlElement()
     fake_node.end_tag_open_offset = 10
     fake_node.end_tag_close_offset = 15
     fake_node.name = fake_tree.root.name
-    fake_context = XmlContext(fake_tree.root, fake_node)
+    fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_node)
     return fake_context
 
 
@@ -67,16 +79,21 @@ def get_context_from_line_position(fake_tree: XsdTree, line: str, position: Posi
 
 
 class TestXmlCompletionServiceClass:
-    def test_init_sets_properties(self, fake_tree: XsdTree) -> None:
+    def test_init_sets_properties(self, fake_tree: XsdTree, fake_definitions_provider: DocumentDefinitionsProvider) -> None:
 
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         assert service.xsd_tree
 
-    def test_get_completion_at_context_with_open_tag_trigger_returns_expected_node(self, fake_tree: XsdTree) -> None:
-        fake_context = XmlContext(fake_tree.root, XmlElement())
+    def test_get_completion_at_context_with_open_tag_trigger_returns_expected_node(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, XmlElement())
         fake_completion_context = CompletionContext(trigger_kind=CompletionTriggerKind.TriggerCharacter, trigger_character="<")
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_completion_at_context(fake_context, fake_completion_context)
 
@@ -87,34 +104,49 @@ class TestXmlCompletionServiceClass:
         assert actual.items[1].label == "expand"
         assert actual.items[1].kind == CompletionItemKind.Class
 
-    def test_get_completion_at_context_with_closing_tag_invoke_returns_none(self, fake_tree: XsdTree) -> None:
+    def test_get_completion_at_context_with_closing_tag_invoke_returns_none(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
         fake_element = XmlElement()
-        fake_context = XmlContext(fake_tree.root, fake_element)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_element)
         fake_completion_context = CompletionContext(trigger_kind=CompletionTriggerKind.Invoked)
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_completion_at_context(fake_context, fake_completion_context)
 
         assert not actual
 
-    def test_get_completion_at_context_inside_cdata_returns_none(self, fake_tree: XsdTree) -> None:
+    def test_get_completion_at_context_inside_cdata_returns_none(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
         fake_element = XmlCDATASection(0, 0)
-        fake_context = XmlContext(fake_tree.root, fake_element)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_element)
         fake_completion_context = CompletionContext(trigger_kind=CompletionTriggerKind.Invoked)
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_completion_at_context(fake_context, fake_completion_context)
 
         assert not actual
 
-    def test_get_completion_at_context_on_node_returns_expected_attributes(self, fake_tree: XsdTree) -> None:
+    def test_get_completion_at_context_on_node_returns_expected_attributes(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
         fake_node = XmlElement()
         fake_node.name = "root"
         fake_node.end_tag_open_offset = 10
         fake_node.end_tag_close_offset = 12
-        fake_context = XmlContext(fake_tree.root, fake_node)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_node)
         fake_completion_context = CompletionContext(trigger_kind=CompletionTriggerKind.TriggerCharacter, trigger_character=" ")
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_completion_at_context(fake_context, fake_completion_context)
 
@@ -124,16 +156,19 @@ class TestXmlCompletionServiceClass:
         assert actual.items[0].kind == CompletionItemKind.Variable
 
     def test_get_completion_at_context_on_node_with_attribute_returns_expected_attributes(
-        self, fake_tree_with_attrs: XsdTree
+        self,
+        fake_tree_with_attrs: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
     ) -> None:
         fake_node = XmlElement()
         fake_node.name = "root"
         fake_node.end_tag_open_offset = 10
         fake_node.end_tag_close_offset = 12
         fake_node.attributes["one"] = XmlAttribute("one", 0, 0, fake_node)
-        fake_context = XmlContext(fake_tree_with_attrs.root, fake_node)
+        fake_context = XmlContext(fake_xml_doc, fake_tree_with_attrs.root, fake_node)
         fake_completion_context = CompletionContext(trigger_kind=CompletionTriggerKind.TriggerCharacter, trigger_character=" ")
-        service = XmlCompletionService(fake_tree_with_attrs)
+        service = XmlCompletionService(fake_tree_with_attrs, fake_definitions_provider)
 
         actual = service.get_completion_at_context(fake_context, fake_completion_context)
 
@@ -144,12 +179,17 @@ class TestXmlCompletionServiceClass:
         assert actual.items[1].label == "three"
         assert actual.items[1].kind == CompletionItemKind.Variable
 
-    def test_get_completion_at_context_on_attr_value_returns_expected_enums(self, fake_tree: XsdTree) -> None:
+    def test_get_completion_at_context_on_attr_value_returns_expected_enums(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
         fake_attr = XmlAttribute("attr", 0, 0, XmlElement())
         fake_attr.set_value(None, 0, 0)
-        fake_context = XmlContext(fake_tree.root, fake_attr.value)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_attr.value)
         fake_completion_context = CompletionContext(trigger_kind=CompletionTriggerKind.Invoked)
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_completion_at_context(fake_context, fake_completion_context)
 
@@ -160,8 +200,13 @@ class TestXmlCompletionServiceClass:
         assert actual.items[1].label == "v2"
         assert actual.items[1].kind == CompletionItemKind.Value
 
-    def test_return_valid_completion_with_node_context(self, fake_tree: XsdTree, fake_context_on_root_node) -> None:
-        service = XmlCompletionService(fake_tree)
+    def test_return_valid_completion_with_node_context(
+        self,
+        fake_tree: XsdTree,
+        fake_context_on_root_node,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_node_completion(fake_context_on_root_node)
 
@@ -169,7 +214,12 @@ class TestXmlCompletionServiceClass:
         assert actual.items[0].label == fake_tree.root.children[0].name
         assert actual.items[1].label == "expand"
 
-    def test_completion_node_reached_max_occurs_return_expected(self, fake_tree: XsdTree, mocker: MockerFixture) -> None:
+    def test_completion_node_reached_max_occurs_return_expected(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
         fake_root = XmlElement()
         fake_root.name = fake_tree.root.name
         fake_root.end_tag_open_offset = 10
@@ -179,42 +229,62 @@ class TestXmlCompletionServiceClass:
         fake_child.parent = fake_root
         fake_child = XmlElement()
         fake_child.parent = fake_root
-        fake_context = XmlContext(fake_tree.root, fake_root)
-        service = XmlCompletionService(fake_tree)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_root)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_node_completion(fake_context)
 
         assert len(actual.items) == 1
         assert actual.items[0].label == "expand"
 
-    def test_completion_return_root_node_when_empty_context(self, fake_tree: XsdTree, fake_empty_context) -> None:
-        service = XmlCompletionService(fake_tree)
+    def test_completion_return_root_node_when_empty_context(
+        self,
+        fake_tree: XsdTree,
+        fake_empty_context,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_node_completion(fake_empty_context)
 
         assert len(actual.items) == 1
         assert actual.items[0].label == fake_tree.root.name
 
-    def test_return_empty_attribute_completion_when_empty_context(self, fake_tree: XsdTree, fake_empty_context) -> None:
-        service = XmlCompletionService(fake_tree)
+    def test_return_empty_attribute_completion_when_empty_context(
+        self,
+        fake_tree: XsdTree,
+        fake_empty_context,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_attribute_completion(fake_empty_context)
 
         assert len(actual.items) == 0
 
-    def test_return_valid_attribute_completion_when_node_context(self, fake_tree: XsdTree, fake_context_on_root_node) -> None:
-        service = XmlCompletionService(fake_tree)
+    def test_return_valid_attribute_completion_when_node_context(
+        self,
+        fake_tree: XsdTree,
+        fake_context_on_root_node,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_attribute_completion(fake_context_on_root_node)
 
         assert len(actual.items) > 0
 
-    def test_return_valid_attribute_value_completion_when_enum_context(self, fake_tree: XsdTree) -> None:
+    def test_return_valid_attribute_value_completion_when_enum_context(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
         fake_attr = XmlAttribute("attr", 0, 0, XmlElement())
         fake_attr.set_value(None, 0, 0)
-        fake_context = XmlContext(fake_tree.root, fake_attr.value)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_attr.value)
 
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
 
         actual = service.get_attribute_value_completion(fake_context)
 
@@ -233,8 +303,9 @@ class TestXmlCompletionServiceClass:
         line_with_mark: str,
         trigger: str,
         expected: str,
+        fake_definitions_provider: DocumentDefinitionsProvider,
     ) -> None:
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
         position, line = TestUtils.extract_mark_from_source("^", line_with_mark)
         fake_context = get_context_from_line_position(fake_tree, line, position)
 
@@ -256,8 +327,9 @@ class TestXmlCompletionServiceClass:
         fake_tree: XsdTree,
         line_with_mark: str,
         trigger: str,
+        fake_definitions_provider: DocumentDefinitionsProvider,
     ) -> None:
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
         position, line = TestUtils.extract_mark_from_source("^", line_with_mark)
         fake_context = get_context_from_line_position(fake_tree, line, position)
 
@@ -278,8 +350,9 @@ class TestXmlCompletionServiceClass:
         line_with_mark: str,
         trigger: str,
         expected_range: Optional[Range],
+        fake_definitions_provider: DocumentDefinitionsProvider,
     ) -> None:
-        service = XmlCompletionService(fake_tree)
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
         position, line = TestUtils.extract_mark_from_source("^", line_with_mark)
         fake_context = get_context_from_line_position(fake_tree, line, position)
 
@@ -287,34 +360,49 @@ class TestXmlCompletionServiceClass:
 
         assert actual.range == expected_range
 
-    def test_auto_close_returns_none_when_at_node_content(self, fake_tree: XsdTree) -> None:
-        service = XmlCompletionService(fake_tree)
+    def test_auto_close_returns_none_when_at_node_content(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
         trigger = ">"
         fake_node = XmlContent(0, 0)
         fake_node.name = fake_tree.root.name
-        fake_context = XmlContext(fake_tree.root, fake_node)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_node)
 
         actual = service.get_auto_close_tag(fake_context, trigger)
 
         assert not actual
 
-    def test_auto_close_returns_none_when_at_cdata(self, fake_tree: XsdTree) -> None:
-        service = XmlCompletionService(fake_tree)
+    def test_auto_close_returns_none_when_at_cdata(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
         trigger = ">"
         fake_node = XmlCDATASection(0, 0)
         fake_node.name = fake_tree.root.name
-        fake_context = XmlContext(fake_tree.root, fake_node)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_node)
 
         actual = service.get_auto_close_tag(fake_context, trigger)
 
         assert not actual
 
-    def test_auto_close_with_slash_returns_none_when_at_cdata(self, fake_tree: XsdTree) -> None:
-        service = XmlCompletionService(fake_tree)
+    def test_auto_close_with_slash_returns_none_when_at_cdata(
+        self,
+        fake_tree: XsdTree,
+        fake_xml_doc: XmlDocument,
+        fake_definitions_provider: DocumentDefinitionsProvider,
+    ) -> None:
+        service = XmlCompletionService(fake_tree, fake_definitions_provider)
         trigger = "/"
         fake_node = XmlCDATASection(0, 0)
         fake_node.name = fake_tree.root.name
-        fake_context = XmlContext(fake_tree.root, fake_node)
+        fake_context = XmlContext(fake_xml_doc, fake_tree.root, fake_node)
 
         actual = service.get_auto_close_tag(fake_context, trigger)
 


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy-language-server/issues/44

Now, when you invoke IntelliSense with `ctrl+space` inside a `macro` attribute in `<expand>` elements, the name of your defined macros across your imported files are suggested:

![macro-name](https://user-images.githubusercontent.com/46503462/116006892-75701f00-a60d-11eb-972c-39f3b43f9db6.gif)
