### PR TITLE
Support dynamic token parameter attributes in <expand> elements

### DIFF
--- a/server/galaxyls/tests/integration/test_completion.py
+++ b/server/galaxyls/tests/integration/test_completion.py
@@ -53,6 +53,21 @@ class TestIntegrationXmlCompletionServiceClass:
                 """,
                 ["macro_1", "macro_2"],
             ),
+            (
+                """
+                <tool id="tool" name="tool">
+                    <macros>
+                        <xml name="color_input" token_varname="myvar" token_default_color="#00ff00" token_label="Pick a color">
+                            <param name="@VARNAME@" type="color" label="@LABEL@" value="@DEFAULT_COLOR@" />
+                        </xml>
+                    </macros>
+                    <inputs>
+                        <expand macro="color_input" ^/>
+                    </inputs>
+                </tool>
+                """,
+                ["varname", "default_color", "label"],
+            ),
         ],
     )
     def test_completion_on_macro_attribute_returns_expected(


### PR DESCRIPTION
xref #44

This allows to auto-complete attributes in `<expand>` elements that reference macros with [dynamic token parameters](https://planemo.readthedocs.io/en/latest/writing_advanced.html#parameterizing-xml-macros-with-tokens).
- The tokens can:
  - display their default value on hover.
  - navigate to their token parameter definition.
- In the `<expand>` element:
  - the attributes will be autocompleted with the name of the token parameter.
  - in addition to the attribute name, the default value will be provided as a placeholder for easy edition/reference.

![token-params](https://user-images.githubusercontent.com/46503462/116817897-ef9e2780-ab68-11eb-962e-cd8628b5280f.gif)
