### PR TITLE
Include Troubleshooting item in the Readme for `pip module not found` error

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -45,7 +45,7 @@ When the extension is activated for the first time, a notification will pop up i
 
 The installation process will try to use the default Python version in your system. If the version is not compatible, it will ask you to enter the path to a compatible version. Just click `Select` in the notification message and you will be able to type the Python path at the top of the window.
 
-This Python version is used to create a virtual environment in which the language server will be installed.
+This Python version is used to create a virtual environment in which the language server will be installed. Please note that on Debian/Ubuntu systems, you may need to install the `python3-venv` package to be able to create the virtual environment including `pip`, otherwise the installation may fail. Please see the [Troubleshooting](#troubleshooting) section below for more information.
 
 ## Troubleshooting
 
@@ -54,6 +54,8 @@ If you encounter any problem during the language server installation, open the V
 Some possible errors:
 
 - `The selected file is not a valid Python <version> path!`. This message will appear if you select a Python binary that is not compatible with the required version. You will be given a chance to select the correct version the next time the extension gets activated. You can force it by reloading the extension or restarting VScode.
+
+- `Error installing the Galaxy Language Server: pip module not found`. The extension needs to create a virtual environment to install the `galaxy-language-server` package and its dependencies. To create a proper environment with `pip` included, in some systems you need to install the `python3-venv` package using the following command: `apt install python3-venv` (you may need to use `sudo`). Once you have `python3-venv` installed, you may need to remove the `glsenv` directory inside the extension installation directory and then restart or reload VSCode to recreate the environment.
 
 # Configuration
 


### PR DESCRIPTION
In some Debian/Ubuntu systems, if the `python3-venv` package is not installed, the virtual environment created by the extension to install the `galaxy-language-server` does not include `pip` and, in this case, the installation may fail.

I have updated the documentation to include this error and the possible solution.