### PR TITLE
Fix empty document validation

### DIFF
--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -123,7 +123,9 @@ def formatting(server: GalaxyToolsLanguageServer, params: DocumentFormattingPara
 @language_server.feature(TEXT_DOCUMENT_DID_OPEN)
 async def did_open(server: GalaxyToolsLanguageServer, params: DidOpenTextDocumentParams) -> None:
     """Occurs when a new xml document is open."""
-    _validate(server, params)
+    document = server.workspace.get_document(params.text_document.uri)
+    if not DocumentValidator.is_empty_document(document):
+        _validate(server, params)
 
 
 @language_server.feature(TEXT_DOCUMENT_DID_SAVE)

--- a/server/galaxyls/services/validation.py
+++ b/server/galaxyls/services/validation.py
@@ -15,12 +15,15 @@ class DocumentValidator:
 
     @classmethod
     def has_valid_root(cls, document: Document) -> bool:
-        """Checks if the document's root element matches one of the supported types."""
+        """Checks if the document's root element matches one of the supported types
+        or is an empty document."""
+        if DocumentValidator.is_empty_document(document):
+            return True
         root = DocumentValidator._get_document_root_tag(document)
         if root is not None:
             root_tag = root.upper()
             supported = [e.name for e in DocumentType if e != DocumentType.UNKNOWN]
-            return root_tag in supported
+            return root_tag == "" or root_tag in supported
         return False
 
     @classmethod
@@ -31,6 +34,11 @@ class DocumentValidator:
             root_tag = root.upper()
             return root_tag == DocumentType.TOOL.name
         return False
+
+    @classmethod
+    def is_empty_document(cls, document: Document) -> bool:
+        """Whether the document is empty or just contains spaces or empty lines."""
+        return not document.source or document.source.isspace()
 
     @classmethod
     def _get_document_root_tag(cls, document: Document) -> Optional[str]:

--- a/server/galaxyls/tests/unit/test_validation.py
+++ b/server/galaxyls/tests/unit/test_validation.py
@@ -70,6 +70,10 @@ class TestDocumentValidatorClass:
     @pytest.mark.parametrize(
         "source, expected",
         [
+            ("<", True),
+            ("", True),
+            ("   ", True),
+            ("  \n ", True),
             ("<tool>", True),
             ("  <tool>", True),
             ("\n<tool>", True),
@@ -82,8 +86,6 @@ class TestDocumentValidatorClass:
             ('<?xml version="1.0" encoding="UTF-8"?>\n<tool>', True),
             ("<macros>", True),
             ('<?xml version="1.0" encoding="UTF-8"?>\n<macros>', True),
-            ("", False),
-            ("   ", False),
             ("test", False),
             ("<test>", False),
         ],


### PR DESCRIPTION
Empty XML documents were considered invalid, this prevented some features like auto-completion to properly work at the beginning.
Empty XML documents are now considered to be Galaxy tool documents by default until the root element is fully declared.
Also, when an empty document is opened, it won't be validated right away to avoid displaying the `Document is empty` validation error but It will be displayed if you attempt to save it though.