### PR TITLE
Fix update expand preview

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -3,6 +3,7 @@
 import { window, Position, SnippetString, Range, ExtensionContext, commands, TextEditor, Uri, workspace, ViewColumn } from "vscode";
 import { RequestType, TextDocumentIdentifier, TextDocumentPositionParams, LanguageClient } from "vscode-languageclient/node";
 import { Constants } from "./constants";
+import { GalaxyToolsExpadedDocumentContentProvider } from "./providers/contentProvider";
 import { changeUriScheme, cloneRange } from "./utils";
 import { DirectoryTreeItem } from "./views/common";
 
@@ -236,6 +237,7 @@ async function previewExpandedDocument() {
         return;
     }
     const expandedDocumentUri = convertToExpandedDocumentUri(document.uri);
+    GalaxyToolsExpadedDocumentContentProvider.getInstance().update(expandedDocumentUri);
     const doc = await workspace.openTextDocument(expandedDocumentUri);
     await window.showTextDocument(doc, { preview: false, viewColumn: ViewColumn.Beside });
 }

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -232,6 +232,9 @@ async function previewExpandedDocument() {
     if (!isSaved) return;
 
     const document = activeEditor.document;
+    if(document.uri.scheme === Constants.EXPAND_DOCUMENT_SCHEMA || document.languageId !== Constants.LANGUAGE_ID){
+        return;
+    }
     const expandedDocumentUri = convertToExpandedDocumentUri(document.uri);
     const doc = await workspace.openTextDocument(expandedDocumentUri);
     await window.showTextDocument(doc, { preview: false, viewColumn: ViewColumn.Beside });

--- a/client/src/providers/contentProvider.ts
+++ b/client/src/providers/contentProvider.ts
@@ -1,9 +1,24 @@
-import { commands, TextDocumentContentProvider, Uri } from "vscode";
+import { commands, Event, EventEmitter, TextDocumentContentProvider, Uri } from "vscode";
 import { Commands, GeneratedExpandedDocument } from "../commands";
 import { Constants } from "../constants";
 import { changeUriScheme } from "../utils";
 
 export class GalaxyToolsExpadedDocumentContentProvider implements TextDocumentContentProvider {
+
+    private static instance: GalaxyToolsExpadedDocumentContentProvider;
+
+    private onDidChangeEmitter = new EventEmitter<Uri>();
+
+
+    private constructor() {
+    }
+
+    public static getInstance(): GalaxyToolsExpadedDocumentContentProvider {
+        if (!this.instance) {
+            this.instance = new GalaxyToolsExpadedDocumentContentProvider();
+        }
+        return this.instance;
+    }
 
     async provideTextDocumentContent(uri: Uri): Promise<string> {
 
@@ -13,6 +28,14 @@ export class GalaxyToolsExpadedDocumentContentProvider implements TextDocumentCo
             return "Can not expand the requested document."
         }
         return result.content;
+    }
+
+    get onDidChange(): Event<Uri> {  
+        return this.onDidChangeEmitter.event;  
+    } 
+
+    public update(documentUri:Uri){
+        this.onDidChangeEmitter.fire(documentUri);
     }
 
     private convertToFileUri(uri: Uri): Uri {

--- a/client/src/providers/setup.ts
+++ b/client/src/providers/setup.ts
@@ -13,7 +13,7 @@ export function setupProviders(client: LanguageClient, context: ExtensionContext
         })
     );
 
-    const expandedDocumentProvider = new GalaxyToolsExpadedDocumentContentProvider();
+    const expandedDocumentProvider = GalaxyToolsExpadedDocumentContentProvider.getInstance();
     context.subscriptions.push(
         workspace.registerTextDocumentContentProvider(Constants.EXPAND_DOCUMENT_SCHEMA, expandedDocumentProvider)
     );


### PR DESCRIPTION
Fixes #147 
This triggers a `provideTextDocumentContent` every time the `galaxytools.preview.expandedDocument`command is executed which should display the updated expanded document in case there are any changes in the source XML tool document.