### PR TITLE
Fix duplicated CodeActions for the same expand document command

### DIFF
--- a/client/src/providers/codeActions.ts
+++ b/client/src/providers/codeActions.ts
@@ -9,16 +9,20 @@ export class GalaxyToolsCodeActionProvider implements CodeActionProvider {
     ];
 
     provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken): ProviderResult<(CodeAction | Command)[]> {
+        const resultCodeActions:CodeAction[] = [];
 
-        return context.diagnostics
-            .filter(diagnostic => diagnostic.code === DiagnosticCodes.INVALID_EXPANDED_TOOL)
-            .map(diagnostic => this.createPreviewExpandedDocumentCommand(diagnostic));
+        const expanded_tool_diagnostics = context.diagnostics.filter(diagnostic => diagnostic.code === DiagnosticCodes.INVALID_EXPANDED_TOOL);
+        if (expanded_tool_diagnostics.length){
+            resultCodeActions.push(this.createPreviewExpandedDocumentCommand(expanded_tool_diagnostics))
+        }
+
+        return resultCodeActions;
     }
 
-    private createPreviewExpandedDocumentCommand(diagnostic: Diagnostic): CodeAction {
+    private createPreviewExpandedDocumentCommand(diagnostics: Diagnostic[]): CodeAction {
         const action = new CodeAction('Preview expanded tool document...', CodeActionKind.Empty);
         action.command = { command: Commands.PREVIEW_EXPANDED_DOCUMENT, title: 'Preview expanded tool document', tooltip: 'This will open a preview of the tool document with all the macros expanded.' };
-        action.diagnostics = [diagnostic];
+        action.diagnostics = diagnostics;
         action.isPreferred = true;
         return action;
     }


### PR DESCRIPTION
Fixes #151 

![Screenshot from 2021-06-07 11-46-06](https://user-images.githubusercontent.com/46503462/121001419-9048be00-c78b-11eb-9dba-a3b7246dd839.png)
