### PR TITLE
Fix `planemo.galaxyRoot` parameter validation in Config

### DIFF
--- a/client/src/configuration/galaxyToolWorkspaceConfiguration.ts
+++ b/client/src/configuration/galaxyToolWorkspaceConfiguration.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { lookpath } from "lookpath"
 import { workspace, WorkspaceConfiguration } from 'vscode';
 
@@ -66,7 +67,7 @@ class GalaxyToolsPlanemoConfiguration implements IPlanemoConfiguration {
 
     private async isValidGalaxyRoot(): Promise<boolean> {
         const galaxyRoot = this.galaxyRoot();
-        if (galaxyRoot === null || !galaxyRoot.endsWith("galaxy") || !await exists(galaxyRoot)) {
+        if (galaxyRoot === null || !await exists(join(galaxyRoot, "lib", "galaxy"))) {
             return false;
         }
         return true;


### PR DESCRIPTION
Check for the existence of `<galaxy_root>/lib/galaxy` instead of relying on how the root directory is named.

This should fix https://github.com/galaxyproject/galaxy-language-server/issues/157

Thank you @lldelisle for reporting!