### PR TITLE
Revert pygls to version 0.11.1

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
-pygls==0.11.2
+pygls==0.11.1
 lxml==4.6.3
 anytree==2.8.0
 galaxy-tool-util==21.1.2


### PR DESCRIPTION
Apparently, pygls 0.11.2 contains some breaking changes affecting https://github.com/galaxyproject/galaxy-language-server/issues/171.

Reverting to the previous version until we found out the exact issue and fix it.