### PR TITLE
Fix wrong argument in get_content_range

### DIFF
--- a/server/galaxyls/services/tools/refactor.py
+++ b/server/galaxyls/services/tools/refactor.py
@@ -231,7 +231,8 @@ class RefactorMacrosService:
         section = tool.find_element(DESCRIPTION)
         if section:
             return tool.get_position_after(section)
-        return tool.get_content_range(TOOL).start
+        root = tool.find_element(TOOL)
+        return tool.get_content_range(root).start
 
     def _get_range_from_line_start(self, range: Range) -> Range:
         """Given an arbitrary document range, returns the same range but with the start offset always at the


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy-language-server/issues/177

When creating a *Code Action* (after selecting a block of XML) to extract a part of the tool as a macro, if there were no macros section defined, the wrong type of parameter could be passed to the `get_content_range` function to determine the insert position, resulting in an error.