### PR TITLE
Make sure the current document is a valid Tool document before processing

### DIFF
--- a/client/src/planemo/testing/main.ts
+++ b/client/src/planemo/testing/main.ts
@@ -20,7 +20,7 @@ export function setupTesting(
     const testProvider = new LanguageServerTestProvider(client);
     const planemoTestRunner = new PlanemoTestRunner();
 
-    const controller = vscode.tests.createTestController("planemo-test-adapter", "Planemo Test Controller");
+    const controller = vscode.tests.createTestController("planemo-test-adapter", "Galaxy Tools - Planemo Tests");
     context.subscriptions.push(controller);
 
     controller.resolveHandler = async (item) => {

--- a/client/src/planemo/testing/main.ts
+++ b/client/src/planemo/testing/main.ts
@@ -6,6 +6,7 @@ import { LanguageClient } from "vscode-languageclient/node";
 import { Settings } from "../../configuration/workspaceConfiguration";
 import { ITestsProvider, testDataMap, testSuiteByUriPath, ToolTestSuite } from "../../testing/common";
 import { LanguageServerTestProvider } from "../../testing/testsProvider";
+import { isGalaxyToolDocument } from "../../utils";
 import { IConfigurationFactory } from "../configuration";
 import { PlanemoTestRunner } from "./testRunner";
 
@@ -98,6 +99,9 @@ async function updateTestNodeFromDocument(
     document: vscode.TextDocument,
     controller: vscode.TestController
 ) {
+    if (!isGalaxyToolDocument(document)) {
+        return;
+    }
     const result = await testProvider.discoverTestsInDocument(document);
     if (result) {
         const suite = refreshTestsFromSuite(controller, result);
@@ -108,6 +112,9 @@ async function updateTestNodeFromDocument(
 }
 
 async function removeTestNodeFromDocument(document: vscode.TextDocument, controller: vscode.TestController) {
+    if (!isGalaxyToolDocument(document)) {
+        return;
+    }
     const suite = testSuiteByUriPath.get(document.uri.fsPath);
     if (suite) {
         controller.items.delete(suite.id);

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -2,8 +2,9 @@
 
 import * as fs from "fs";
 import { exec } from "child_process";
-import { Position, Range, Uri } from "vscode";
+import { Position, Range, TextDocument, Uri } from "vscode";
 import { ICommand } from "./interfaces";
+import { Constants } from "./constants";
 
 export async function execAsync(command: string, options: object = {}): Promise<string> {
     return new Promise((resolve, reject) => {
@@ -63,6 +64,13 @@ export function getCommands(command: string): ICommand {
         external: `gls.${command}`,
         internal: `galaxytools.${command}`,
     };
+}
+
+export function isGalaxyToolDocument(document: TextDocument): boolean {
+    return (
+        document.uri.path.endsWith(`.${Constants.TOOL_DOCUMENT_EXTENSION}`) &&
+        document.languageId === Constants.LANGUAGE_ID
+    );
 }
 
 /**

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -295,4 +295,6 @@ def _get_xml_document(document: Document) -> XmlDocument:
 
 def _is_document_supported(document: Document) -> bool:
     """Returns True if the given document is supported by the server."""
+    if not document.uri.lower().endswith(".xml"):
+        return False
     return DocumentValidator.has_valid_root(document)


### PR DESCRIPTION
Fixes #188

Other kinds of documents (even .git documents) were leaking into the test discovery process resulting in errors. Now only valid XML Galaxy tool documents are processed.