### PR TITLE
Remove local virtual environment when install fails

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -8,7 +8,7 @@ This extension provides XML validation, tags and attributes completion, help/doc
 
 ## Requires ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/galaxy-language-server)
 
-To use the [Galaxy Language Server](https://pypi.org/project/galaxy-language-server/) features you need Python 3.8+ installed on your system. See the [Installation](#Installation) section for more details.
+To use the [Galaxy Language Server](https://pypi.org/project/galaxy-language-server/) features you need Python 3.8+ installed on your system. See the [Installation](#Installation) section for more details. The extension will create ins own Python virtual environment using `python3-venv`. You might need to install it in your system before installing the extension with `apt install python3-venv`.
 
 ## Planemo
 
@@ -52,7 +52,7 @@ Some possible errors:
 
 -   `The selected file is not a valid Python <version> path!`. This message will appear if you select a Python binary that is not compatible with the required version. You will be given a chance to select the correct version the next time the extension gets activated. You can force it by reloading the extension or restarting VScode.
 
--   `Error installing the Galaxy Language Server: pip module not found`. The extension needs to create a virtual environment to install the `galaxy-language-server` package and its dependencies. To create a proper environment with `pip` included, in some systems you need to install the `python3-venv` package using the following command: `apt install python3-venv` (you might need to use `sudo`). Once you have `python3-venv` installed, if the extension installation keeps failing, you need to remove the `glsenv` directory inside the extension installation directory (usually `~/.vscode/extensions/davelopez.galaxy-tools-X.X.X/glsenv`) and then restart or reload VSCode to recreate the environment.
+-   `Error installing the Galaxy Language Server: pip module not found`. The extension needs to create a virtual environment to install the `galaxy-language-server` package and its dependencies. To create a proper environment with `pip` included, in some systems you need to install the `python3-venv` package using the following command: `apt install python3-venv` (you might need to use `sudo`). Once you have `python3-venv` installed, try reloading VSCode and the extension should be installed successfully. If the extension installation keeps failing, you need to manually remove the `glsenv` directory inside the extension installation directory (usually `~/.vscode/extensions/davelopez.galaxy-tools-X.X.X/glsenv`) and then restart or reload VSCode to recreate the environment.
 
 # Configuration
 

--- a/client/README.md
+++ b/client/README.md
@@ -52,7 +52,7 @@ Some possible errors:
 
 -   `The selected file is not a valid Python <version> path!`. This message will appear if you select a Python binary that is not compatible with the required version. You will be given a chance to select the correct version the next time the extension gets activated. You can force it by reloading the extension or restarting VScode.
 
--   `Error installing the Galaxy Language Server: pip module not found`. The extension needs to create a virtual environment to install the `galaxy-language-server` package and its dependencies. To create a proper environment with `pip` included, in some systems you need to install the `python3-venv` package using the following command: `apt install python3-venv` (you may need to use `sudo`). Once you have `python3-venv` installed, you may need to remove the `glsenv` directory inside the extension installation directory and then restart or reload VSCode to recreate the environment.
+-   `Error installing the Galaxy Language Server: pip module not found`. The extension needs to create a virtual environment to install the `galaxy-language-server` package and its dependencies. To create a proper environment with `pip` included, in some systems you need to install the `python3-venv` package using the following command: `apt install python3-venv` (you might need to use `sudo`). Once you have `python3-venv` installed, if the extension installation keeps failing, you need to remove the `glsenv` directory inside the extension installation directory (usually `~/.vscode/extensions/davelopez.galaxy-tools-X.X.X/glsenv`) and then restart or reload VSCode to recreate the environment.
 
 # Configuration
 

--- a/client/src/setup.ts
+++ b/client/src/setup.ts
@@ -17,7 +17,7 @@ export async function installLanguageServer(context: ExtensionContext): Promise<
     // Check if the LS is already installed
     let venvPath = getVirtualEnvironmentPath(context.extensionPath, Constants.LS_VENV_NAME);
     if (existsSync(venvPath)) {
-        const venvPython = getPythonFromVenvPath(venvPath);
+        const venvPython = getPythonFromVirtualEnvPath(venvPath);
         const isInstalled = await isPythonPackageInstalled(
             venvPython,
             Constants.GALAXY_LS_PACKAGE,
@@ -102,11 +102,11 @@ export async function installLanguageServer(context: ExtensionContext): Promise<
                         );
                     }
 
-                    const venvPython = getPythonFromVenvPath(venvPath);
+                    const venvPython = getPythonFromVirtualEnvPath(venvPath);
                     console.log(`[gls] Using Python from: ${venvPython}`);
 
                     console.log(`[gls] Installing ${Constants.GALAXY_LS_PACKAGE}...`);
-                    const isInstalled = await intallPythonPackage(
+                    const isInstalled = await installPythonPackage(
                         venvPython,
                         Constants.GALAXY_LS_PACKAGE,
                         Constants.GALAXY_LS_VERSION
@@ -135,7 +135,7 @@ export async function installLanguageServer(context: ExtensionContext): Promise<
     );
 }
 
-function getPythonFromVenvPath(venvPath: string): string {
+function getPythonFromVirtualEnvPath(venvPath: string): string {
     return Constants.IS_WIN
         ? join(venvPath, "Scripts", Constants.PYTHON_WIN)
         : join(venvPath, "bin", Constants.PYTHON_UNIX);
@@ -157,9 +157,9 @@ async function isPythonPackageInstalled(python: string, packageName: string, ver
     }
 
     const pattern = /Version: (?<version>\d+.\d+.\d+)/m;
-    const getPacakgeInfoCmd = `"${python}" -m pip show ${packageName}`;
+    const getPackageInfoCmd = `"${python}" -m pip show ${packageName}`;
     try {
-        const packageInfo = await execAsync(getPacakgeInfoCmd);
+        const packageInfo = await execAsync(getPackageInfoCmd);
         const match = packageInfo.match(new RegExp(pattern));
         console.log(`[gls] Version found: ${packageName} - ${match?.groups?.version}`);
         return version === match?.groups?.version;
@@ -169,13 +169,13 @@ async function isPythonPackageInstalled(python: string, packageName: string, ver
     }
 }
 
-async function intallPythonPackage(python: string, packageName: string, version: string): Promise<boolean> {
+async function installPythonPackage(python: string, packageName: string, version: string): Promise<boolean> {
     const installPipPackageCmd = `"${python}" -m pip install ${packageName}==${version}`;
     try {
         await execAsync(installPipPackageCmd);
         return isPythonPackageInstalled(python, packageName, version);
     } catch (err: any) {
-        console.error(`[gls] intallPythonPackage err: ${err}`);
+        console.error(`[gls] installPythonPackage err: ${err}`);
         return false;
     }
 }
@@ -231,8 +231,8 @@ async function selectPythonUsingFileDialog(): Promise<string | undefined> {
 async function createVirtualEnvironment(python: string, name: string, cwd: string): Promise<string> {
     const path = getVirtualEnvironmentPath(cwd, name);
     if (!existsSync(path)) {
-        const createVenvCmd = `"${python}" -m venv ${name}`;
-        await execAsync(createVenvCmd, { cwd });
+        const createVirtualEnvCmd = `"${python}" -m venv ${name}`;
+        await execAsync(createVirtualEnvCmd, { cwd });
     }
     return path;
 }

--- a/client/src/setup.ts
+++ b/client/src/setup.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { commands, ExtensionContext, ProgressLocation, Uri, window, workspace } from "vscode";
 import { Constants } from "./constants";
-import { execAsync } from "./utils";
+import { execAsync, forceDeleteDirectory as removeDirectory } from "./utils";
 import { LocalStorageService } from "./configuration/storage";
 
 /**
@@ -115,6 +115,7 @@ export async function installLanguageServer(context: ExtensionContext): Promise<
                     if (!isInstalled) {
                         const errorMessage = "There was a problem trying to install the Galaxy language server.";
                         window.showErrorMessage(errorMessage);
+                        removeDirectory(venvPath);
                         throw new Error(errorMessage);
                     }
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -50,6 +50,10 @@ export async function exists(path: string): Promise<boolean> {
         .catch(() => false);
 }
 
+export function forceDeleteDirectory(directory: string) {
+    fs.rmSync(directory, { recursive: true, force: true });
+}
+
 export function changeUriScheme(uri: Uri, scheme: string): Uri {
     if (uri.scheme === scheme) {
         return uri;


### PR DESCRIPTION
Fixes #195

- Automatically remove the local virtual environment directory `glsenv` when the installation fails. This will try to recreate the full virtual environment on each reload if the server is not installed instead of reusing the broken environment or making the user manually remove it.
- Improve the documentation to make it more obvious that `python3-venv` is a prerequisite.
