### PR TITLE
Migrate to pygls v1

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.10']
+        python-version: ['3.8', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: ['3.8', '3.10']
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -22,11 +23,11 @@ jobs:
       - name: Set up Python for local environment
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm install
       - name: Run integration tests
         run: xvfb-run -a npm run test:e2e

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.8', '3.10']
+        python-version: ['3.8', '3.10', '3.11']
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.10']
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -24,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2237,9 +2237,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5240,9 +5240,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,14 +1,14 @@
 "use strict";
 
 import * as net from "net";
-import { ExtensionContext, window, IndentAction, LanguageConfiguration, languages, ExtensionMode } from "vscode";
+import { ExtensionContext, ExtensionMode, IndentAction, LanguageConfiguration, languages, window } from "vscode";
 import { LanguageClient, LanguageClientOptions, ServerOptions } from "vscode-languageclient/node";
-import { installLanguageServer } from "./setup";
-import { Constants } from "./constants";
 import { setupCommands } from "./commands";
-import { setupPlanemo } from "./planemo/main";
+import { Constants } from "./constants";
 import { DefaultConfigurationFactory } from "./planemo/configuration";
+import { setupPlanemo } from "./planemo/main";
 import { setupProviders } from "./providers/setup";
+import { installLanguageServer } from "./setup";
 
 let client: LanguageClient;
 
@@ -76,13 +76,16 @@ function getClientOptions(): LanguageClientOptions {
  */
 function connectToLanguageServerTCP(port: number): LanguageClient {
     const serverOptions: ServerOptions = () => {
-        return new Promise((resolve, _reject) => {
+        return new Promise((resolve, reject) => {
             const clientSocket = new net.Socket();
             clientSocket.connect(port, "127.0.0.1", () => {
                 resolve({
                     reader: clientSocket,
                     writer: clientSocket,
                 });
+            });
+            clientSocket.on("error", (err) => {
+                reject(err);
             });
         });
     };

--- a/server/galaxyls/__main__.py
+++ b/server/galaxyls/__main__.py
@@ -9,18 +9,21 @@ logging.basicConfig(filename="galaxy-language-server.log", level=logging.DEBUG, 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.description = "Galaxy Language Server"
 
-    parser.add_argument("--tcp", action="store_true", help="Use TCP server instead of stdio")
+    parser.add_argument("--tcp", action="store_true", help="Use TCP server")
+    parser.add_argument("--ws", action="store_true", help="Use WebSocket server")
     parser.add_argument("--host", default="127.0.0.1", help="Bind to this address")
     parser.add_argument("--port", type=int, default=2087, help="Bind to this port")
 
 
-def main() -> None:
+def main():
     parser = argparse.ArgumentParser()
     add_arguments(parser)
     args = parser.parse_args()
 
     if args.tcp:
         language_server.start_tcp(args.host, args.port)
+    elif args.ws:
+        language_server.start_ws(args.host, args.port)
     else:
         language_server.start_io()
 

--- a/server/galaxyls/config.py
+++ b/server/galaxyls/config.py
@@ -1,12 +1,7 @@
 from enum import Enum
+from typing import Optional
 
-from pydantic import BaseModel
-
-
-def to_camel(string: str) -> str:
-    pascal = "".join(word.capitalize() for word in string.split("_"))
-    camel = pascal[0].lower() + pascal[1:]
-    return camel
+import attrs
 
 
 class CompletionMode(str, Enum):
@@ -15,20 +10,45 @@ class CompletionMode(str, Enum):
     DISABLED = "disabled"
 
 
-class ConfigModel(BaseModel):
-    class Config:
-        alias_generator = to_camel
-        allow_population_by_field_name = True
-
-
-class CompletionConfig(ConfigModel):
+@attrs.define
+class CompletionConfig:
     """Auto-completion feature configuration."""
 
-    mode: CompletionMode = CompletionMode.AUTO
-    auto_close_tags: bool = True
+    mode: CompletionMode = attrs.field(default=CompletionMode.AUTO)
+    auto_close_tags: bool = attrs.field(default=True, alias="autoCloseTags")
 
 
-class GalaxyToolsConfiguration(ConfigModel):
+@attrs.define
+class ServerConfig:
+    """Language Server specific configuration."""
+
+    silent_install: bool = attrs.field(default=False, alias="silentInstall")
+
+
+@attrs.define
+class PlanemoTestingConfig:
+    """Planemo testing configuration."""
+
+    enabled: bool = attrs.field(default=True)
+    auto_test_discover_on_save_enabled: bool = attrs.field(default=True, alias="autoTestDiscoverOnSaveEnabled")
+    extra_params: str = attrs.field(default="", alias="extraParams")
+
+
+@attrs.define
+class PlanemoConfig:
+    """Planemo integration configuration."""
+
+    enabled: bool = attrs.field(default=False)
+    binary_path: str = attrs.field(default="planemo", alias="binaryPath")
+    galaxy_root: Optional[str] = attrs.field(default=None, alias="galaxyRoot")
+    get_cwd: Optional[str] = attrs.field(default=None, alias="getCwd")
+    testing: PlanemoTestingConfig = attrs.field(default=PlanemoTestingConfig())
+
+
+@attrs.define
+class GalaxyToolsConfiguration:
     """Galaxy Language Server general configuration."""
 
-    completion: CompletionConfig = CompletionConfig()
+    server: ServerConfig = attrs.field(default=ServerConfig())
+    completion: CompletionConfig = attrs.field(default=CompletionConfig())
+    planemo: PlanemoConfig = attrs.field(default=PlanemoConfig())

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -5,19 +5,7 @@ from typing import (
     Optional,
 )
 
-from pygls.lsp.methods import (
-    CODE_ACTION,
-    COMPLETION,
-    DEFINITION,
-    FORMATTING,
-    HOVER,
-    INITIALIZED,
-    TEXT_DOCUMENT_DID_CLOSE,
-    TEXT_DOCUMENT_DID_OPEN,
-    TEXT_DOCUMENT_DID_SAVE,
-    WORKSPACE_DID_CHANGE_CONFIGURATION,
-)
-from pygls.lsp.types import (
+from lsprotocol.types import (
     CodeAction,
     CodeActionKind,
     CodeActionOptions,
@@ -34,12 +22,22 @@ from pygls.lsp.types import (
     DidSaveTextDocumentParams,
     DocumentFormattingParams,
     Hover,
+    INITIALIZED,
     InitializeParams,
     Location,
     MessageType,
+    TEXT_DOCUMENT_CODE_ACTION,
+    TEXT_DOCUMENT_COMPLETION,
+    TEXT_DOCUMENT_DEFINITION,
+    TEXT_DOCUMENT_DID_CLOSE,
+    TEXT_DOCUMENT_DID_OPEN,
+    TEXT_DOCUMENT_DID_SAVE,
+    TEXT_DOCUMENT_FORMATTING,
+    TEXT_DOCUMENT_HOVER,
     TextDocumentIdentifier,
     TextDocumentPositionParams,
     TextEdit,
+    WORKSPACE_DID_CHANGE_CONFIGURATION,
 )
 from pygls.server import LanguageServer
 from pygls.workspace import Document
@@ -105,7 +103,7 @@ async def did_change_configuration(server: GalaxyToolsLanguageServer, params: Di
     server.show_message("Settings updated")
 
 
-@language_server.feature(COMPLETION, CompletionOptions(trigger_characters=["<", " "]))
+@language_server.feature(TEXT_DOCUMENT_COMPLETION, CompletionOptions(trigger_characters=["<", " "]))
 def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> Optional[CompletionList]:
     """Returns completion items depending on the current document context."""
     if server.configuration.completion.mode == CompletionMode.DISABLED:
@@ -117,7 +115,7 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
     return None
 
 
-@language_server.feature(HOVER)
+@language_server.feature(TEXT_DOCUMENT_HOVER)
 def hover(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[Hover]:
     """Displays Markdown documentation for the element under the cursor."""
     document = _get_valid_document(server, params.text_document.uri)
@@ -127,7 +125,7 @@ def hover(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams)
     return None
 
 
-@language_server.feature(FORMATTING)
+@language_server.feature(TEXT_DOCUMENT_FORMATTING)
 def formatting(server: GalaxyToolsLanguageServer, params: DocumentFormattingParams) -> Optional[List[TextEdit]]:
     """Formats the whole document using the provided parameters"""
     document = _get_valid_document(server, params.text_document.uri)
@@ -157,7 +155,7 @@ def did_close(server: GalaxyToolsLanguageServer, params: DidCloseTextDocumentPar
     server.publish_diagnostics(params.text_document.uri, [])
 
 
-@language_server.feature(DEFINITION)
+@language_server.feature(TEXT_DOCUMENT_DEFINITION)
 def definition(server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams) -> Optional[List[Location]]:
     """Provides the location of a symbol definition."""
     document = _get_valid_document(server, params.text_document.uri)
@@ -168,7 +166,7 @@ def definition(server: GalaxyToolsLanguageServer, params: TextDocumentPositionPa
 
 
 @language_server.feature(
-    CODE_ACTION,
+    TEXT_DOCUMENT_CODE_ACTION,
     CodeActionOptions(
         code_action_kinds=[
             CodeActionKind.RefactorExtract,

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -166,7 +166,7 @@ def definition(server: GalaxyToolsLanguageServer, params: TextDocumentPositionPa
     document = _get_valid_document(server, params.text_document.uri)
     if document:
         xml_document = _get_xml_document(document)
-        return server.service.definitions_provider.go_to_definition(xml_document, params.position)
+        return server.service.go_to_definition(xml_document, params.position)
     return None
 
 

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -61,12 +61,15 @@ from galaxyls.types import (
 )
 from galaxyls.utils import deserialize_command_param
 
+GLS_VERSION = "0.9.0"
+GLS_NAME = "galaxy-tools-language-server"
+
 
 class GalaxyToolsLanguageServer(LanguageServer):
     """Galaxy Tools Language Server."""
 
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(name=GLS_NAME, version=GLS_VERSION)
         self.service = GalaxyToolLanguageService()
         self.configuration: GalaxyToolsConfiguration = GalaxyToolsConfiguration()
 

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -14,7 +14,6 @@ from lsprotocol.types import (
     CompletionOptions,
     CompletionParams,
     ConfigurationItem,
-    ConfigurationParams,
     Diagnostic,
     DidChangeConfigurationParams,
     DidCloseTextDocumentParams,
@@ -38,6 +37,7 @@ from lsprotocol.types import (
     TextDocumentPositionParams,
     TextEdit,
     WORKSPACE_DID_CHANGE_CONFIGURATION,
+    WorkspaceConfigurationParams,
 )
 from pygls.server import LanguageServer
 from pygls.workspace import Document
@@ -85,7 +85,9 @@ async def _load_client_config_async(server: GalaxyToolsLanguageServer) -> None:
         server (GalaxyToolsLanguageServer): The language server instance.
     """
     try:
-        config = await server.get_configuration_async(ConfigurationParams(items=[ConfigurationItem(section="galaxyTools")]))
+        config = await server.get_configuration_async(
+            WorkspaceConfigurationParams(items=[ConfigurationItem(section="galaxyTools")])
+        )
         server.configuration = GalaxyToolsConfiguration(**config[0])
     except BaseException as err:
         server.show_message_log(f"Error loading configuration: {err}")

--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -6,7 +6,7 @@ from typing import (
     Optional,
 )
 
-from pygls.lsp.types import (
+from lsprotocol.types import (
     CompletionContext,
     CompletionItem,
     CompletionItemKind,

--- a/server/galaxyls/services/context.py
+++ b/server/galaxyls/services/context.py
@@ -6,7 +6,7 @@ from typing import (
     Optional,
 )
 
-from pygls.lsp.types import Range
+from lsprotocol.types import Range
 from pygls.workspace import Position
 
 from galaxyls.services.tools.constants import MACROS

--- a/server/galaxyls/services/context.py
+++ b/server/galaxyls/services/context.py
@@ -239,8 +239,8 @@ class XmlContextService:
             return xsd_node
         return None
 
-    def get_range_for_context(self, xml_document: XmlDocument, context: XmlContext) -> Range:
+    def get_range_for_context(self, xml_document: XmlDocument, context: XmlContext) -> Optional[Range]:
         if context.node is None:
-            return Range()
+            return None
         start_offset, end_offset = context.node.get_offsets(context.offset)
         return convert_document_offsets_to_range(xml_document.document, start_offset, end_offset)

--- a/server/galaxyls/services/definitions.py
+++ b/server/galaxyls/services/definitions.py
@@ -3,7 +3,7 @@ from typing import (
     Optional,
 )
 
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Location,
     Position,
 )

--- a/server/galaxyls/services/format.py
+++ b/server/galaxyls/services/format.py
@@ -4,13 +4,13 @@ best practices.
 
 from typing import List
 
-from lxml import etree
-from pygls.lsp.types import (
+from lsprotocol.types import (
     DocumentFormattingParams,
     Position,
     Range,
     TextEdit,
 )
+from lxml import etree
 
 DEFAULT_INDENTATION = " " * 4
 

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -3,7 +3,7 @@ from typing import (
     Optional,
 )
 
-from pygls.lsp.types import (
+from lsprotocol.types import (
     CodeAction,
     CodeActionParams,
     CompletionList,

--- a/server/galaxyls/services/tools/common.py
+++ b/server/galaxyls/services/tools/common.py
@@ -4,7 +4,7 @@ from typing import (
     Optional,
 )
 
-from pygls.lsp.types import Diagnostic
+from lsprotocol.types import Diagnostic
 from pygls.workspace import Workspace
 
 from galaxyls.services.xml.document import XmlDocument

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -7,7 +7,7 @@ from typing import (
 )
 
 from anytree import find
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )

--- a/server/galaxyls/services/tools/generators/command.py
+++ b/server/galaxyls/services/tools/generators/command.py
@@ -7,7 +7,7 @@ from typing import (
 )
 
 from anytree import PreOrderIter
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )

--- a/server/galaxyls/services/tools/generators/snippets.py
+++ b/server/galaxyls/services/tools/generators/snippets.py
@@ -11,11 +11,11 @@ from typing import (
 )
 
 from galaxy.util import xml_macros
-from lxml import etree
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )
+from lxml import etree
 from pygls.workspace import Document
 
 from galaxyls.services.tools.constants import (

--- a/server/galaxyls/services/tools/generators/tests.py
+++ b/server/galaxyls/services/tools/generators/tests.py
@@ -6,11 +6,11 @@ from typing import (
     Union,
 )
 
-from lxml import etree
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )
+from lxml import etree
 
 from galaxyls.services.tools.constants import (
     ARGUMENT,

--- a/server/galaxyls/services/tools/linting.py
+++ b/server/galaxyls/services/tools/linting.py
@@ -6,7 +6,7 @@ from galaxy.tool_util.lint import (
     LintLevel,
     XMLLintMessageXPath,
 )
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Diagnostic,
     DiagnosticSeverity,
 )

--- a/server/galaxyls/services/tools/macros.py
+++ b/server/galaxyls/services/tools/macros.py
@@ -5,8 +5,8 @@ from typing import (
     Set,
 )
 
+from lsprotocol.types import Location
 from pydantic import BaseModel
-from pygls.lsp.types import Location
 from pygls.workspace import Workspace
 
 from galaxyls.services.tools.constants import (

--- a/server/galaxyls/services/tools/macros.py
+++ b/server/galaxyls/services/tools/macros.py
@@ -5,8 +5,8 @@ from typing import (
     Set,
 )
 
+import attrs
 from lsprotocol.types import Location
-from pydantic import BaseModel
 from pygls.workspace import Workspace
 
 from galaxyls.services.tools.constants import (
@@ -21,29 +21,28 @@ from galaxyls.services.xml.nodes import XmlElement
 from galaxyls.services.xml.parser import XmlDocumentParser
 
 
-class BaseMacrosModel(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
-
-
-class TokenDefinition(BaseModel):
+@attrs.define
+class TokenDefinition:
     name: str
     location: Location
     value: str
 
 
+@attrs.define
 class TokenParam(TokenDefinition):
     param_name: str
     default_value: str
 
 
-class MacroDefinition(BaseModel):
+@attrs.define
+class MacroDefinition:
     name: str
     location: Location
     token_params: Dict[str, TokenParam]
 
 
-class ImportedMacrosFile(BaseMacrosModel):
+@attrs.define
+class ImportedMacrosFile:
     file_name: str
     file_uri: Optional[str]
     document: Optional[XmlDocument]
@@ -51,7 +50,8 @@ class ImportedMacrosFile(BaseMacrosModel):
     macros: Dict[str, MacroDefinition]
 
 
-class ToolMacroDefinitions(BaseMacrosModel):
+@attrs.define
+class ToolMacroDefinitions:
     tool_document: XmlDocument
     imported_macros: Dict[str, ImportedMacrosFile]
     tokens: Dict[str, TokenDefinition]

--- a/server/galaxyls/services/tools/macros.py
+++ b/server/galaxyls/services/tools/macros.py
@@ -16,7 +16,10 @@ from galaxyls.services.tools.constants import (
     XML,
 )
 from galaxyls.services.tools.document import GalaxyToolXmlDocument
-from galaxyls.services.xml.document import XmlDocument
+from galaxyls.services.xml.document import (
+    DEFAULT_RANGE,
+    XmlDocument,
+)
 from galaxyls.services.xml.nodes import XmlElement
 from galaxyls.services.xml.parser import XmlDocumentParser
 
@@ -59,7 +62,7 @@ class ToolMacroDefinitions:
 
     def go_to_import_definition(self, file_name: str) -> Optional[List[Location]]:
         imported_macros = self.imported_macros.get(file_name)
-        if imported_macros and imported_macros.document and imported_macros.document.root:
+        if imported_macros and imported_macros.document and imported_macros.document.root and imported_macros.file_uri:
             macros_file_uri = imported_macros.file_uri
             content_range = imported_macros.document.get_full_range(imported_macros.document.root)
             if content_range:
@@ -157,7 +160,7 @@ class MacroDefinitionsProvider:
                 name=name,
                 location=Location(
                     uri=macros_xml.document.uri,
-                    range=macros_xml.get_full_range(element),
+                    range=macros_xml.get_full_range(element) or DEFAULT_RANGE,
                 ),
                 value=value,
             )
@@ -172,10 +175,10 @@ class MacroDefinitionsProvider:
         for element in macro_elements:
             name = element.get_attribute(NAME)
             macro_def = MacroDefinition(
-                name=name,
+                name=name or "Unknown",
                 location=Location(
                     uri=macros_xml.document.uri,
-                    range=macros_xml.get_full_range(element),
+                    range=macros_xml.get_full_range(element) or DEFAULT_RANGE,
                 ),
                 token_params=self.get_token_params(macros_xml, element),
             )
@@ -196,7 +199,7 @@ class MacroDefinitionsProvider:
                     value=f"**Token parameter**\n- Default value: `{default_value}`",
                     location=Location(
                         uri=macros_xml.document.uri,
-                        range=macros_xml.get_full_range(attr),
+                        range=macros_xml.get_full_range(attr) or DEFAULT_RANGE,
                     ),
                 )
                 token_params[token_name] = token_param

--- a/server/galaxyls/services/tools/refactor.py
+++ b/server/galaxyls/services/tools/refactor.py
@@ -8,6 +8,7 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+import attrs
 from lsprotocol.types import (
     CodeAction,
     CodeActionKind,
@@ -22,7 +23,6 @@ from lsprotocol.types import (
     WorkspaceEdit,
 )
 from lxml import etree
-from pydantic.main import BaseModel
 from pygls.workspace import Workspace
 
 from galaxyls.services.format import GalaxyToolFormatService
@@ -47,7 +47,8 @@ DEFAULT_MACROS_FILENAME = "macros.xml"
 EXCLUDED_TAGS = {TOOL, MACROS, MACRO, XML}
 
 
-class MacroData(BaseModel):
+@attrs.define
+class MacroData:
     name: str
     content: str
 

--- a/server/galaxyls/services/tools/refactor.py
+++ b/server/galaxyls/services/tools/refactor.py
@@ -8,9 +8,7 @@ from typing import (
 )
 from urllib.parse import urlparse
 
-from lxml import etree
-from pydantic.main import BaseModel
-from pygls.lsp.types import (
+from lsprotocol.types import (
     CodeAction,
     CodeActionKind,
     CodeActionParams,
@@ -23,6 +21,8 @@ from pygls.lsp.types import (
     VersionedTextDocumentIdentifier,
     WorkspaceEdit,
 )
+from lxml import etree
+from pydantic.main import BaseModel
 from pygls.workspace import Workspace
 
 from galaxyls.services.format import GalaxyToolFormatService

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -8,11 +8,11 @@ from typing import (
 
 from anytree.search import findall
 from galaxy.util import xml_macros
-from lxml import etree
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )
+from lxml import etree
 from pygls.workspace import Document
 
 from .nodes import (

--- a/server/galaxyls/services/xml/nodes.py
+++ b/server/galaxyls/services/xml/nodes.py
@@ -135,7 +135,7 @@ class XmlContainerNode(XmlSyntaxNode):
     def get_content_offsets(self) -> Tuple[int, int]:
         return NotImplemented
 
-    def get_content(self, source: str) -> Optional[str]:
+    def get_content(self, source: str) -> str:
         """Gets the text content from the source between the content offsets of this element."""
         start, end = self.get_content_offsets()
         return source[start:end]

--- a/server/galaxyls/services/xml/utils.py
+++ b/server/galaxyls/services/xml/utils.py
@@ -9,7 +9,7 @@ from typing import (
     List,
 )
 
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )

--- a/server/galaxyls/services/xsd/service.py
+++ b/server/galaxyls/services/xsd/service.py
@@ -7,12 +7,12 @@ from typing import (
     Optional,
 )
 
-from lxml import etree
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Diagnostic,
     MarkupContent,
     MarkupKind,
 )
+from lxml import etree
 
 from galaxyls.services.context import XmlContext
 from galaxyls.services.xml.document import XmlDocument

--- a/server/galaxyls/services/xsd/types.py
+++ b/server/galaxyls/services/xsd/types.py
@@ -16,11 +16,11 @@ from anytree import (
     Resolver,
     ResolverError,
 )
-from lxml import etree
-from pygls.lsp.types import (
+from lsprotocol.types import (
     MarkupContent,
     MarkupKind,
 )
+from lxml import etree
 
 from .constants import MSG_NO_DOCUMENTATION_AVAILABLE
 

--- a/server/galaxyls/services/xsd/validation.py
+++ b/server/galaxyls/services/xsd/validation.py
@@ -4,14 +4,14 @@
 from pathlib import Path
 from typing import List
 
-from lxml import etree
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Diagnostic,
     DiagnosticRelatedInformation,
     Location,
     Position,
     Range,
 )
+from lxml import etree
 
 from galaxyls.constants import DiagnosticCodes
 from galaxyls.services.tools.document import GalaxyToolXmlDocument

--- a/server/galaxyls/services/xsd/validation.py
+++ b/server/galaxyls/services/xsd/validation.py
@@ -15,7 +15,10 @@ from lxml import etree
 
 from galaxyls.constants import DiagnosticCodes
 from galaxyls.services.tools.document import GalaxyToolXmlDocument
-from galaxyls.services.xml.document import XmlDocument
+from galaxyls.services.xml.document import (
+    DEFAULT_RANGE,
+    XmlDocument,
+)
 
 EXPAND_DOCUMENT_URI_SUFFIX = "%20%28Expanded%29"
 
@@ -156,7 +159,7 @@ class GalaxyToolSchemaValidationService:
     def _build_diagnostics_for_macros_file_syntax_error(self, xml_document: XmlDocument, syntax_error) -> List[Diagnostic]:
         tool = GalaxyToolXmlDocument.from_xml_document(xml_document)
         result = Diagnostic(
-            range=tool.get_import_macro_file_range(syntax_error.filename),
+            range=tool.get_import_macro_file_range(syntax_error.filename) or DEFAULT_RANGE,
             message=syntax_error.msg,
             source=self.diagnostics_source,
             related_information=[

--- a/server/galaxyls/tests/integration/test_completion.py
+++ b/server/galaxyls/tests/integration/test_completion.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import pytest
-from pygls.lsp.types import (
+from lsprotocol.types import (
     CompletionContext,
     CompletionTriggerKind,
 )

--- a/server/galaxyls/tests/integration/tools/test_iuc.py
+++ b/server/galaxyls/tests/integration/tools/test_iuc.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 import pytest
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )

--- a/server/galaxyls/tests/unit/test_config.py
+++ b/server/galaxyls/tests/unit/test_config.py
@@ -1,4 +1,5 @@
 from galaxyls.config import (
+    CompletionConfig,
     CompletionMode,
     GalaxyToolsConfiguration,
 )
@@ -6,14 +7,9 @@ from galaxyls.config import (
 
 class TestGalaxyToolsConfigurationClass:
     def test_init_sets_properties(self) -> None:
-        mock_config = {
-            "completion": {
-                "mode": "invoke",
-                "autoCloseTags": "false",
-            },
-        }
+        fake_completion_config = CompletionConfig(mode=CompletionMode.INVOKE, auto_close_tags=False)
 
-        config = GalaxyToolsConfiguration(**mock_config)
+        config = GalaxyToolsConfiguration(fake_completion_config)
 
         assert config.completion.mode == CompletionMode.INVOKE
         assert not config.completion.auto_close_tags

--- a/server/galaxyls/tests/unit/test_config.py
+++ b/server/galaxyls/tests/unit/test_config.py
@@ -2,14 +2,20 @@ from galaxyls.config import (
     CompletionConfig,
     CompletionMode,
     GalaxyToolsConfiguration,
+    ServerConfig,
 )
 
 
 class TestGalaxyToolsConfigurationClass:
     def test_init_sets_properties(self) -> None:
-        fake_completion_config = CompletionConfig(mode=CompletionMode.INVOKE, auto_close_tags=False)
+        fake_server_config = ServerConfig()
+        fake_server_config.silent_install = True
+        fake_completion_config = CompletionConfig()
+        fake_completion_config.mode = CompletionMode.INVOKE
+        fake_completion_config.auto_close_tags = False
 
-        config = GalaxyToolsConfiguration(fake_completion_config)
+        config = GalaxyToolsConfiguration(server=fake_server_config, completion=fake_completion_config)
 
+        assert config.server.silent_install is True
         assert config.completion.mode == CompletionMode.INVOKE
-        assert not config.completion.auto_close_tags
+        assert config.completion.auto_close_tags is False

--- a/server/galaxyls/tests/unit/test_format.py
+++ b/server/galaxyls/tests/unit/test_format.py
@@ -1,4 +1,4 @@
-from pygls.lsp.types import (
+from lsprotocol.types import (
     DocumentFormattingParams,
     FormattingOptions,
     TextDocumentIdentifier,

--- a/server/galaxyls/tests/unit/test_tools.py
+++ b/server/galaxyls/tests/unit/test_tools.py
@@ -1,5 +1,5 @@
 import pytest
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )

--- a/server/galaxyls/tests/unit/test_utils.py
+++ b/server/galaxyls/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from pygls.lsp.types.basic_structures import Position
+from lsprotocol.types import Position
 
 from galaxyls.tests.unit.utils import TestUtils
 

--- a/server/galaxyls/tests/unit/utils.py
+++ b/server/galaxyls/tests/unit/utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Tuple
 
-from pygls.lsp.types import Position
+from lsprotocol.types import Position
 from pygls.workspace import Document
 
 from ...services.xml.constants import NEW_LINE

--- a/server/galaxyls/tests/unit/xml/test_parser.py
+++ b/server/galaxyls/tests/unit/xml/test_parser.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from pygls.lsp.types import Position
+from lsprotocol.types import Position
 from pygls.workspace import Document
 
 from ....services.xml.nodes import (

--- a/server/galaxyls/tests/unit/xml/test_utils.py
+++ b/server/galaxyls/tests/unit/xml/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )

--- a/server/galaxyls/types.py
+++ b/server/galaxyls/types.py
@@ -7,11 +7,11 @@ from typing import (
     Optional,
 )
 
+import attrs
 from lsprotocol.types import (
     Position,
     Range,
 )
-from pydantic.main import BaseModel
 
 CommandParameters = List[Any]
 
@@ -83,8 +83,9 @@ class TestSuiteInfoResult:
         self.children = children
 
 
-class GeneratedExpandedDocument(BaseModel):
+@attrs.define
+class GeneratedExpandedDocument:
     """Represents a tool document with all the macros expanded."""
 
-    content: Optional[str]
-    error_message: Optional[str]
+    content: Optional[str] = attrs.field(default=None)
+    error_message: Optional[str] = attrs.field(default=None, alias="errorMessage")

--- a/server/galaxyls/types.py
+++ b/server/galaxyls/types.py
@@ -7,11 +7,11 @@ from typing import (
     Optional,
 )
 
-from pydantic.main import BaseModel
-from pygls.lsp.types import (
+from lsprotocol.types import (
     Position,
     Range,
 )
+from pydantic.main import BaseModel
 
 CommandParameters = List[Any]
 

--- a/server/galaxyls/utils.py
+++ b/server/galaxyls/utils.py
@@ -34,7 +34,7 @@ def unpack(obj):
 
 
 def deserialize_command_param(params: NamedTuple, type: Type[T]) -> T:
-    """Given a namedtuple, converts it into the given type of pydantic model."""
+    """Given a namedtuple, converts it into the given model type."""
     params_dict = unpack(params)
     obj = type(**params_dict)  # type: ignore [call-arg]
     return obj

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,4 +2,3 @@ pygls==1.0.1
 lxml==4.9.2
 anytree==2.8.0
 galaxy-tool-util==22.1.5
-pydantic==1.10.4

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,5 @@
-pygls==0.11.3
-lxml==4.9.1
+pygls==1.0.1
+lxml==4.9.2
 anytree==2.8.0
-galaxy-tool-util==22.1.2
-pydantic==1.8.2
+galaxy-tool-util==22.1.5
+pydantic==1.10.4

--- a/server/setup.py
+++ b/server/setup.py
@@ -7,8 +7,10 @@ from setuptools import (
     setup,
 )
 
+from galaxyls.server import GLS_VERSION
+
 PACKAGE_NAME = "galaxy-language-server"
-VERSION = "0.9.0"
+VERSION = GLS_VERSION
 AUTHOR = "David López"
 AUTHOR_EMAIL = "davelopez7391@gmail.com"
 DESCRIPTION = "A language server for Galaxy (https://galaxyproject.org) tool wrappers"

--- a/server/setup.py
+++ b/server/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=packages,
     include_package_data=True,
     install_requires=requirements,
-    python_requires="~=3.8",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
@@ -51,5 +51,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
Migrate to `pygls` version 1.0.1 following the [migration guide](https://pygls.readthedocs.io/en/latest/pages/migrating-to-v1.html).

Mostly update imports and switch from pydantic custom models to [attrs](https://www.attrs.org/en/stable/index.html) and [cattrs](https://cattrs.readthedocs.io/en/stable/) for serialization and deserialization.
