### PR TITLE
Fix config loading with new attrs classes

### DIFF
--- a/server/galaxyls/config.py
+++ b/server/galaxyls/config.py
@@ -39,7 +39,7 @@ class PlanemoConfig:
     """Planemo integration configuration."""
 
     enabled: bool = attrs.field(default=False)
-    binary_path: str = attrs.field(default="planemo", alias="binaryPath")
+    env_path: str = attrs.field(default="planemo", alias="envPath")
     galaxy_root: Optional[str] = attrs.field(default=None, alias="galaxyRoot")
     get_cwd: Optional[str] = attrs.field(default=None, alias="getCwd")
     testing: PlanemoTestingConfig = attrs.field(default=PlanemoTestingConfig())
@@ -52,3 +52,13 @@ class GalaxyToolsConfiguration:
     server: ServerConfig = attrs.field(default=ServerConfig())
     completion: CompletionConfig = attrs.field(default=CompletionConfig())
     planemo: PlanemoConfig = attrs.field(default=PlanemoConfig())
+
+    @classmethod
+    def from_config_dict(cls, config: dict):
+        result = GalaxyToolsConfiguration(
+            server=ServerConfig(**config["server"]),
+            completion=CompletionConfig(**config["completion"]),
+            planemo=PlanemoConfig(**config["planemo"]),
+        )
+        result.planemo.testing = PlanemoTestingConfig(**config["planemo"]["testing"])
+        return result

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -88,7 +88,7 @@ async def _load_client_config_async(server: GalaxyToolsLanguageServer) -> None:
         config = await server.get_configuration_async(
             WorkspaceConfigurationParams(items=[ConfigurationItem(section="galaxyTools")])
         )
-        server.configuration = GalaxyToolsConfiguration(**config[0])
+        server.configuration = GalaxyToolsConfiguration.from_config_dict(config[0])
     except BaseException as err:
         server.show_message_log(f"Error loading configuration: {err}")
         server.show_message("Error loading configuration. Using default settings.", MessageType.Error)

--- a/server/galaxyls/tests/unit/test_config.py
+++ b/server/galaxyls/tests/unit/test_config.py
@@ -19,3 +19,27 @@ class TestGalaxyToolsConfigurationClass:
         assert config.server.silent_install is True
         assert config.completion.mode == CompletionMode.INVOKE
         assert config.completion.auto_close_tags is False
+
+    def test_init_configuration_from_dict(self):
+        config_dict = {
+            "server": {"silentInstall": False},
+            "completion": {"mode": "disabled", "autoCloseTags": True},
+            "planemo": {
+                "enabled": True,
+                "envPath": "/path/to/planemo",
+                "galaxyRoot": "/path/to/galaxy",
+                "testing": {"enabled": True, "autoTestDiscoverOnSaveEnabled": True, "extraParams": "--debug"},
+            },
+        }
+
+        config = GalaxyToolsConfiguration.from_config_dict(config_dict)
+
+        assert config.server.silent_install is False
+        assert config.completion.mode == CompletionMode.DISABLED
+        assert config.completion.auto_close_tags is True
+        assert config.planemo.enabled is True
+        assert config.planemo.env_path == "/path/to/planemo"
+        assert config.planemo.galaxy_root == "/path/to/galaxy"
+        assert config.planemo.testing.enabled is True
+        assert config.planemo.testing.auto_test_discover_on_save_enabled is True
+        assert config.planemo.testing.extra_params == "--debug"


### PR DESCRIPTION
Fixes #219

Apparently, the new `attrs` models (replacing previous pydantic models) in `pygls` cannot work with nested dictionaries on initialization. I probably should have kept using pydantic models, but I wanted to remove the extra dependency so... this should fix it.