### PR TITLE
Add DocumentLinksProvider and support test-data file links

### DIFF
--- a/server/galaxyls/constants.py
+++ b/server/galaxyls/constants.py
@@ -1,4 +1,8 @@
 """This module contains definitions for constants used by the Galaxy Tools Language Server."""
+from lsprotocol.types import (
+    Position,
+    Range,
+)
 
 
 class Commands:
@@ -14,3 +18,10 @@ class Commands:
 
 class DiagnosticCodes:
     INVALID_EXPANDED_TOOL = 101
+
+
+# Default Document Range and the start of the document
+DEFAULT_DOCUMENT_RANGE = Range(
+    start=Position(line=0, character=0),
+    end=Position(line=0, character=0),
+)

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -20,6 +20,8 @@ from lsprotocol.types import (
     DidOpenTextDocumentParams,
     DidSaveTextDocumentParams,
     DocumentFormattingParams,
+    DocumentLink,
+    DocumentLinkParams,
     Hover,
     INITIALIZED,
     InitializeParams,
@@ -31,6 +33,7 @@ from lsprotocol.types import (
     TEXT_DOCUMENT_DID_CLOSE,
     TEXT_DOCUMENT_DID_OPEN,
     TEXT_DOCUMENT_DID_SAVE,
+    TEXT_DOCUMENT_DOCUMENT_LINK,
     TEXT_DOCUMENT_FORMATTING,
     TEXT_DOCUMENT_HOVER,
     TextDocumentIdentifier,
@@ -168,6 +171,15 @@ def definition(server: GalaxyToolsLanguageServer, params: TextDocumentPositionPa
         xml_document = _get_xml_document(document)
         return server.service.go_to_definition(xml_document, params.position)
     return None
+
+
+@language_server.feature(TEXT_DOCUMENT_DOCUMENT_LINK)
+def document_link(server: GalaxyToolsLanguageServer, params: DocumentLinkParams) -> List[DocumentLink]:
+    document = _get_valid_document(server, params.text_document.uri)
+    if document:
+        xml_document = _get_xml_document(document)
+        return server.service.link_provider.get_document_links(xml_document)
+    return []
 
 
 @language_server.feature(

--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -116,7 +116,7 @@ class XmlCompletionService:
                 result.append(self._build_attribute_completion_item(attr, len(result)))
             if context.node.name == "expand":
                 element = cast(XmlElement, context.node)
-                macro_name = element.get_attribute("macro")
+                macro_name = element.get_attribute_value("macro")
                 if macro_name:
                     token_params = self.definitions_provider.macro_definitions_provider.get_macro_token_params(
                         context.xml_document, macro_name

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -24,6 +24,7 @@ from pygls.workspace import (
 )
 
 from galaxyls.services.definitions import DocumentDefinitionsProvider
+from galaxyls.services.links import DocumentLinksProvider
 from galaxyls.services.macros import MacroExpanderService
 from galaxyls.services.tools.common import (
     TestsDiscoveryService,
@@ -73,6 +74,7 @@ class GalaxyToolLanguageService:
         self.refactoring_service: Optional[RefactoringService] = None
         self.linter = GalaxyToolLinter()
         self.definitions_provider: Optional[DocumentDefinitionsProvider] = None
+        self.link_provider = DocumentLinksProvider()
 
     def set_workspace(self, workspace: Workspace) -> None:
         macro_definitions_provider = MacroDefinitionsProvider(workspace)

--- a/server/galaxyls/services/links.py
+++ b/server/galaxyls/services/links.py
@@ -1,0 +1,42 @@
+from typing import List
+
+from lsprotocol.types import DocumentLink
+
+from galaxyls.services.tools.document import GalaxyToolXmlDocument
+from galaxyls.services.xml.document import XmlDocument
+from galaxyls.services.xml.utils import convert_document_offsets_to_range
+
+
+class DocumentLinksProvider:
+    """Provides links to external resources defined in the document."""
+
+    def get_document_links(self, xml_document: XmlDocument) -> List[DocumentLink]:
+        tool = GalaxyToolXmlDocument.from_xml_document(xml_document)
+        test_data_file_links = self._get_test_data_file_links(tool)
+        return test_data_file_links
+
+    def _get_test_data_file_links(self, tool: GalaxyToolXmlDocument) -> List[DocumentLink]:
+        result: List[DocumentLink] = []
+        for test in tool.get_tests():
+            params = filter(lambda e: e.name == "param", test.elements)
+            for param in params:
+                value_attr = param.attributes.get("value")
+                if value_attr is None or value_attr.value is None:
+                    # Must have a value
+                    continue
+
+                filename = value_attr.get_value()
+                if filename is None or "." not in filename:
+                    # Must be a filename with extension
+                    continue
+
+                test_data_file_path = tool.get_test_data_path() / filename
+                start_offset, end_offset = value_attr.value.get_unquoted_content_offsets()
+                link_range = convert_document_offsets_to_range(tool.xml_document.document, start_offset, end_offset)
+                result.append(
+                    DocumentLink(
+                        target=test_data_file_path.as_uri(),
+                        range=link_range,
+                    )
+                )
+        return result

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -209,7 +209,7 @@ class GalaxyToolXmlDocument:
     def get_tool_id(self) -> Optional[str]:
         """Gets the identifier of the tool"""
         tool_element = self.get_tool_element()
-        return tool_element.get_attribute("id") if tool_element else None
+        return tool_element.get_attribute_value("id") if tool_element else None
 
     def get_tests(self) -> List[XmlElement]:
         """Gets the tests of this document as a list of elements.

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -147,6 +147,17 @@ class GalaxyToolXmlDocument:
         inputs = self.find_element(INPUTS)
         return GalaxyToolInputTree(inputs)
 
+    def get_inputs(self) -> List[XmlElement]:
+        """Gets the inputs of this document as a list of elements.
+
+        Returns:
+            List[XmlElement]: The outputs defined in the document.
+        """
+        outputs = self.find_element(INPUTS)
+        if outputs:
+            return outputs.elements
+        return []
+
     def get_outputs(self) -> List[XmlElement]:
         """Gets the outputs of this document as a list of elements.
 

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -230,6 +230,11 @@ class GalaxyToolXmlDocument:
             return range
         return None
 
+    def get_test_data_path(self) -> Path:
+        """Gets the test-data directory path of the tool"""
+        tool_directory = self._get_tool_directory()
+        return tool_directory / "test-data"
+
     @classmethod
     def from_xml_document(cls, xml_document: XmlDocument) -> "GalaxyToolXmlDocument":
         return GalaxyToolXmlDocument(xml_document.document, xml_document)

--- a/server/galaxyls/services/tools/generators/command.py
+++ b/server/galaxyls/services/tools/generators/command.py
@@ -152,17 +152,17 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
     def _param_to_cheetah(self, param: XmlElement, name_path: Optional[str] = None, indent_level: int = 0) -> str:
         """Converts the given param element to it's Cheetah representation."""
         indentation = self._get_indentation(indent_level)
-        argument_attr = param.get_attribute(ARGUMENT)
-        name_attr = param.get_attribute(NAME)
+        argument_attr = param.get_attribute_value(ARGUMENT)
+        name_attr = param.get_attribute_value(NAME)
         if not name_attr and argument_attr:
             name_attr = argument_attr.lstrip(DASH).replace(DASH, UNDERSCORE)
-        type_attr = param.get_attribute(TYPE)
+        type_attr = param.get_attribute_value(TYPE)
         if name_path:
             name_attr = f"{name_path}.{name_attr}"
         if type_attr == BOOLEAN:
             return f"{indentation}\\${name_attr}"
         if type_attr in [INTEGER, FLOAT]:
-            if param.get_attribute(OPTIONAL) == "true":
+            if param.get_attribute_value(OPTIONAL) == "true":
                 return (
                     f"{indentation}#if str(\\${name_attr}):\n"
                     f"{indentation}{self.indent_spaces}{self._get_argument_safe(argument_attr)} \\${name_attr}"
@@ -193,7 +193,7 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
         if name_path:
             cond_name = f"{name_path}.{cond_name}"
         if conditional.option_param:
-            param_name = conditional.option_param.get_attribute(NAME)
+            param_name = conditional.option_param.get_attribute_value(NAME)
             option = conditional.option
             directive = "#elif"
             if conditional.is_first_option:
@@ -209,7 +209,7 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
         indentation = self._get_indentation(indent_level)
         result: List[str] = []
         if repeat.element:
-            repeat_name = repeat.element.get_attribute(NAME)
+            repeat_name = repeat.element.get_attribute_value(NAME)
             if name_path:
                 repeat_name = f"{name_path}.{repeat_name}"
             var_placeholder = self._get_next_tabstop_with_placeholder(REPEAT_VAR)
@@ -224,7 +224,7 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
         """Converts the given section node to it's Cheetah representation."""
         result: List[str] = []
         if section.element:
-            section_name = section.element.get_attribute(NAME)
+            section_name = section.element.get_attribute_value(NAME)
             if name_path:
                 section_name = f"{name_path}.{section_name}"
             result.extend(self._node_to_cheetah(section, section_name, indent_level))
@@ -232,7 +232,7 @@ class GalaxyToolCommandSnippetGenerator(SnippetGenerator):
 
     def _output_to_cheetah(self, output: XmlElement) -> Optional[str]:
         """Converts the given output element to it's Cheetah representation wrapped in single quotes."""
-        name = output.get_attribute(NAME)
+        name = output.get_attribute_value(NAME)
         if name:
             return f"'\\${name}'"
         return None

--- a/server/galaxyls/services/tools/generators/tests.py
+++ b/server/galaxyls/services/tools/generators/tests.py
@@ -206,22 +206,22 @@ class GalaxyToolTestSnippetGenerator(SnippetGenerator):
             etree._Element: The XML element representing a <param> in the <test> code snippet.
         """
         param = etree.Element(PARAM)
-        argument_attr = input_param.get_attribute(ARGUMENT)
-        name_attr = input_param.get_attribute(NAME)
+        argument_attr = input_param.get_attribute_value(ARGUMENT)
+        name_attr = input_param.get_attribute_value(NAME)
         if not name_attr and argument_attr:
             name_attr = self._extract_name_from_argument(argument_attr)
         if name_attr:
             param.attrib[NAME] = name_attr
-        default_value = input_param.get_attribute(VALUE)
+        default_value = input_param.get_attribute_value(VALUE)
         if value:
             param.attrib[VALUE] = value
         elif default_value:
             param.attrib[VALUE] = self._get_next_tabstop_with_placeholder(default_value)
         else:
-            type_attr = input_param.get_attribute(TYPE)
+            type_attr = input_param.get_attribute_value(TYPE)
             if type_attr:
                 if type_attr == BOOLEAN:
-                    default_value = input_param.get_attribute(CHECKED)
+                    default_value = input_param.get_attribute_value(CHECKED)
                     param.attrib[VALUE] = self._get_next_tabstop_with_options(BOOLEAN_OPTIONS, default_value)
                 elif type_attr == SELECT or type_attr == TEXT:
                     try:
@@ -241,7 +241,7 @@ class GalaxyToolTestSnippetGenerator(SnippetGenerator):
         if input_conditional.option_param:
             # add the option param
             param_element = self._build_param_test_element(input_conditional.option_param, input_conditional.option)
-            if input_conditional.option_param.get_attribute(TYPE) == BOOLEAN:
+            if input_conditional.option_param.get_attribute_value(TYPE) == BOOLEAN:
                 conditional.append(etree.Comment(BOOLEAN_CONDITIONAL_NOT_RECOMMENDED_COMMENT))
             conditional.append(param_element)
         # add the rest of params in the corresponding when element
@@ -291,7 +291,7 @@ class GalaxyToolTestSnippetGenerator(SnippetGenerator):
             output (XmlElement): The
             test_element (etree._Element): [description]
         """
-        name = data.get_attribute(NAME)
+        name = data.get_attribute_value(NAME)
         if name:
             output_element = etree.Element(OUTPUT)
             output_element.attrib[NAME] = name
@@ -305,11 +305,11 @@ class GalaxyToolTestSnippetGenerator(SnippetGenerator):
             output_collection (XmlElement): The <collection> XML element.
             test_element (etree._Element): The <test> XML element.
         """
-        name = output_collection.get_attribute(NAME)
+        name = output_collection.get_attribute_value(NAME)
         if name:
             output_element = etree.Element(OUTPUT_COLLECTION)
             output_element.attrib[NAME] = name
-            type_attr = output_collection.get_attribute(TYPE)
+            type_attr = output_collection.get_attribute_value(TYPE)
             if type_attr:
                 output_element.attrib[TYPE] = type_attr
             element = etree.Element(ELEMENT)
@@ -361,5 +361,5 @@ class GalaxyToolTestSnippetGenerator(SnippetGenerator):
             List[str]: The list of <option> in this 'param' or an empty list.
         """
         option_elements = param.get_children_with_name(OPTION)
-        options = [o.get_attribute(VALUE) for o in option_elements]
+        options = [o.get_attribute_value(VALUE) for o in option_elements]
         return list(filter(None, options))

--- a/server/galaxyls/services/tools/inputs.py
+++ b/server/galaxyls/services/tools/inputs.py
@@ -77,16 +77,18 @@ class ConditionalInputNode(InputNode):
     def _get_options(self) -> List[str]:
         try:
             if self.option_param:
-                type_attr = self.option_param.get_attribute(TYPE)
+                type_attr = self.option_param.get_attribute_value(TYPE)
                 if type_attr == SELECT:
                     option_elements = self.option_param.get_children_with_name(OPTION)
-                    return list(filter(None, [option_element.get_attribute(VALUE) for option_element in option_elements]))
+                    return list(
+                        filter(None, [option_element.get_attribute_value(VALUE) for option_element in option_elements])
+                    )
                 elif type_attr == BOOLEAN:
                     options = []
-                    true_value = self.option_param.get_attribute(TRUEVALUE)
+                    true_value = self.option_param.get_attribute_value(TRUEVALUE)
                     if true_value:
                         options.append(true_value)
-                    false_value = self.option_param.get_attribute(FALSEVALUE)
+                    false_value = self.option_param.get_attribute_value(FALSEVALUE)
                     if false_value:
                         options.append(false_value)
                     return options
@@ -158,16 +160,16 @@ class GalaxyToolInputTree:
             parent (InputNode): The InputNode that will hold the conditional branches and it's elements.
         """
         param = conditional.elements[0]  # first child must be select or boolean
-        if param.get_attribute(TYPE) == SELECT:
+        if param.get_attribute_value(TYPE) == SELECT:
             options = param.get_children_with_name(OPTION)
             for option in options:
-                option_value = option.get_attribute(VALUE)
+                option_value = option.get_attribute_value(VALUE)
                 self._build_conditional_option_branch(conditional, parent, option_value)
-        elif param.get_attribute(TYPE) == BOOLEAN:
-            true_value = param.get_attribute(TRUEVALUE)
+        elif param.get_attribute_value(TYPE) == BOOLEAN:
+            true_value = param.get_attribute_value(TRUEVALUE)
             if true_value:
                 self._build_conditional_option_branch(conditional, parent, true_value)
-            false_value = param.get_attribute(FALSEVALUE)
+            false_value = param.get_attribute_value(FALSEVALUE)
             if false_value:
                 self._build_conditional_option_branch(conditional, parent, false_value)
 
@@ -181,11 +183,11 @@ class GalaxyToolInputTree:
             parent (InputNode): The input node that will contain this branch.
             option_value (str): The value of the option selected in this conditional branch.
         """
-        name = conditional.get_attribute(NAME)
+        name = conditional.get_attribute_value(NAME)
         if name and option_value:
             conditional_node = ConditionalInputNode(name, option_value, element=conditional, parent=parent)
             when = find(
-                conditional, filter_=lambda el: el.name == WHEN and el.get_attribute(VALUE) == option_value, maxlevel=2
+                conditional, filter_=lambda el: el.name == WHEN and el.get_attribute_value(VALUE) == option_value, maxlevel=2
             )
             when = cast(XmlElement, when)
             if when:
@@ -201,10 +203,10 @@ class GalaxyToolInputTree:
         Returns:
             Optional[RepeatInputNode]: The resulting RepeatInputNode with it's own input children.
         """
-        name = repeat.get_attribute(NAME)
+        name = repeat.get_attribute_value(NAME)
         if name:
             min = 1
-            min_attr = repeat.get_attribute(MIN)
+            min_attr = repeat.get_attribute_value(MIN)
             if min_attr and min_attr.isdigit():
                 min = int(min_attr)
             repeat_node = RepeatInputNode(name, min, repeat)
@@ -221,7 +223,7 @@ class GalaxyToolInputTree:
         Returns:
             Optional[SectionInputNode]: The resulting SectionInputNode with it's own input children.
         """
-        name = section.get_attribute(NAME)
+        name = section.get_attribute_value(NAME)
         if name:
             section_node = SectionInputNode(name, section)
             self._build_input_tree(section, section_node)

--- a/server/galaxyls/services/tools/macros.py
+++ b/server/galaxyls/services/tools/macros.py
@@ -148,7 +148,7 @@ class MacroDefinitionsProvider:
         token_elements = macros_xml.find_all_elements_with_name(TOKEN)
         rval = {}
         for element in token_elements:
-            token = element.get_attribute(NAME)
+            token = element.get_attribute_value(NAME)
             if token is None:
                 continue
             name = token.replace("@", "")
@@ -170,7 +170,7 @@ class MacroDefinitionsProvider:
         macro_elements += xml_elements
         rval = {}
         for element in macro_elements:
-            name = element.get_attribute(NAME)
+            name = element.get_attribute_value(NAME)
             macro_def = MacroDefinition(
                 name=name or "Unknown",
                 location=Location(

--- a/server/galaxyls/services/tools/macros.py
+++ b/server/galaxyls/services/tools/macros.py
@@ -16,10 +16,7 @@ from galaxyls.services.tools.constants import (
     XML,
 )
 from galaxyls.services.tools.document import GalaxyToolXmlDocument
-from galaxyls.services.xml.document import (
-    DEFAULT_RANGE,
-    XmlDocument,
-)
+from galaxyls.services.xml.document import XmlDocument
 from galaxyls.services.xml.nodes import XmlElement
 from galaxyls.services.xml.parser import XmlDocumentParser
 
@@ -160,7 +157,7 @@ class MacroDefinitionsProvider:
                 name=name,
                 location=Location(
                     uri=macros_xml.document.uri,
-                    range=macros_xml.get_full_range(element) or DEFAULT_RANGE,
+                    range=macros_xml.get_full_range(element) or XmlDocument.DEFAULT_RANGE,
                 ),
                 value=value,
             )
@@ -178,7 +175,7 @@ class MacroDefinitionsProvider:
                 name=name or "Unknown",
                 location=Location(
                     uri=macros_xml.document.uri,
-                    range=macros_xml.get_full_range(element) or DEFAULT_RANGE,
+                    range=macros_xml.get_full_range(element) or XmlDocument.DEFAULT_RANGE,
                 ),
                 token_params=self.get_token_params(macros_xml, element),
             )
@@ -199,7 +196,7 @@ class MacroDefinitionsProvider:
                     value=f"**Token parameter**\n- Default value: `{default_value}`",
                     location=Location(
                         uri=macros_xml.document.uri,
-                        range=macros_xml.get_full_range(attr) or DEFAULT_RANGE,
+                        range=macros_xml.get_full_range(attr) or XmlDocument.DEFAULT_RANGE,
                     ),
                 )
                 token_params[token_name] = token_param

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -15,6 +15,7 @@ from lsprotocol.types import (
 from lxml import etree
 from pygls.workspace import Document
 
+from galaxyls.constants import DEFAULT_DOCUMENT_RANGE
 from .nodes import (
     XmlContainerNode,
     XmlElement,
@@ -29,17 +30,14 @@ from .utils import (
     convert_document_offsets_to_range,
 )
 
-DEFAULT_RANGE = Range(
-    start=Position(line=0, character=0),
-    end=Position(line=0, character=0),
-)
-
 
 class XmlDocument(XmlSyntaxNode):
     """Represents a parsed XML document.
 
     This is the root of the XML syntax tree.
     """
+
+    DEFAULT_RANGE = DEFAULT_DOCUMENT_RANGE
 
     def __init__(self, document: Document):
         super().__init__()
@@ -268,8 +266,8 @@ class XmlDocument(XmlSyntaxNode):
     def get_default_range(self) -> Range:
         """Gets the range of the root tag or the first character of the document if there is no root."""
         if self.root:
-            return self.get_element_name_range(self.root) or DEFAULT_RANGE
-        return DEFAULT_RANGE
+            return self.get_element_name_range(self.root) or self.DEFAULT_RANGE
+        return self.DEFAULT_RANGE
 
     def get_tree_element_from_xpath(self, tree, xpath: Optional[str]) -> Optional[Any]:
         if xpath is None or tree is None:

--- a/server/galaxyls/services/xml/nodes.py
+++ b/server/galaxyls/services/xml/nodes.py
@@ -178,7 +178,7 @@ class XmlAttribute(XmlSyntaxNode):
         self.parent = owner
 
     def __repr__(self) -> str:
-        return f"[{self.name}={self.get_value()}]"
+        return f"XmlAttribute[{self.name}={self.get_value()}]"
 
     @property
     def node_type(self) -> NodeType:
@@ -268,7 +268,12 @@ class XmlAttributeValue(XmlContainerNode):
         return self.owner.name
 
     def get_content_offsets(self) -> Tuple[int, int]:
+        """Gets the content offsets of this attribute value."""
         return self.start, self.end
+
+    def get_unquoted_content_offsets(self) -> Tuple[int, int]:
+        """Gets the content offsets of this attribute value without the quoting marks."""
+        return self.start + 1, self.end - 1
 
 
 class XmlElement(XmlContainerNode):

--- a/server/galaxyls/services/xml/nodes.py
+++ b/server/galaxyls/services/xml/nodes.py
@@ -350,7 +350,7 @@ class XmlElement(XmlContainerNode):
         """Gets the list of attribute names of this node if it has any."""
         return [*self.attributes]
 
-    def get_attribute(self, name: str) -> Optional[str]:
+    def get_attribute_value(self, name: str) -> Optional[str]:
         """Gets the value of the attribute with the given name if it exists.
 
         Args:

--- a/server/galaxyls/services/xsd/validation.py
+++ b/server/galaxyls/services/xsd/validation.py
@@ -15,10 +15,7 @@ from lxml import etree
 
 from galaxyls.constants import DiagnosticCodes
 from galaxyls.services.tools.document import GalaxyToolXmlDocument
-from galaxyls.services.xml.document import (
-    DEFAULT_RANGE,
-    XmlDocument,
-)
+from galaxyls.services.xml.document import XmlDocument
 
 EXPAND_DOCUMENT_URI_SUFFIX = "%20%28Expanded%29"
 
@@ -159,7 +156,7 @@ class GalaxyToolSchemaValidationService:
     def _build_diagnostics_for_macros_file_syntax_error(self, xml_document: XmlDocument, syntax_error) -> List[Diagnostic]:
         tool = GalaxyToolXmlDocument.from_xml_document(xml_document)
         result = Diagnostic(
-            range=tool.get_import_macro_file_range(syntax_error.filename) or DEFAULT_RANGE,
+            range=tool.get_import_macro_file_range(syntax_error.filename) or XmlDocument.DEFAULT_RANGE,
             message=syntax_error.msg,
             source=self.diagnostics_source,
             related_information=[

--- a/server/galaxyls/tests/integration/tools/test_document_links.py
+++ b/server/galaxyls/tests/integration/tools/test_document_links.py
@@ -1,0 +1,65 @@
+from lsprotocol.types import (
+    Position,
+    Range,
+)
+
+from galaxyls.services.links import DocumentLinksProvider
+from galaxyls.tests.unit.utils import TestUtils
+
+
+class TestDocumentLinksProviderClass:
+    def test_returns_no_links_when_no_test_params(self) -> None:
+        xml_document = TestUtils.from_source_to_xml_document(
+            """
+<tool>
+    <tests>
+    </tests>
+</tool>
+"""
+        )
+
+        provider = DocumentLinksProvider()
+
+        actual = provider.get_document_links(xml_document)
+
+        assert actual == []
+
+    def test_returns_only_file_links(self) -> None:
+        xml_document = TestUtils.from_source_to_xml_document(
+            """
+<tool>
+    <inputs>
+        <param name="input1" type="data" format="txt"/>
+        <param name="input2" type="data" format="txt"/>
+        <param name="num" type="integer" format="txt"/>
+        <param name="empty" type="data" format="txt"/>
+        <param name="bool_param" type="boolean"/>
+    </inputs>
+    <tests>
+        <test>
+            <param name="input1" value="my test file.txt"/>
+            <param name="bool_param" value="false"/>
+        </test>
+        <test>
+            <param name="input2" value="data_file_without_extension"/>
+            <param name="num" value="3"/>
+            <param name="empty" value=""/>
+        </test>
+    </tests>
+</tool>
+"""
+        )
+
+        provider = DocumentLinksProvider()
+
+        actual = provider.get_document_links(xml_document)
+
+        assert len(actual) == 2
+
+        assert actual[0].target is not None
+        assert actual[0].target.endswith("/test-data/my%20test%20file.txt")
+        assert actual[0].range == Range(start=Position(line=11, character=40), end=Position(line=11, character=56))
+
+        assert actual[1].target is not None
+        assert actual[1].target.endswith("/test-data/data_file_without_extension")
+        assert actual[1].range == Range(start=Position(line=15, character=40), end=Position(line=15, character=67))


### PR DESCRIPTION
Closes #176

In addition to what was already supported to navigate to macro files and definitions, now you can also follow links to your test files.

![Screenshot from 2023-08-20 16-12-41](https://github.com/galaxyproject/galaxy-language-server/assets/46503462/4fd0cd6b-02a1-4750-9b59-757c2fb7c22c)

### TODO
- [x] Add some tests