### PR TITLE
Fix macros detection condition

### DIFF
--- a/client/tests/e2e/suite/extension.e2e.ts
+++ b/client/tests/e2e/suite/extension.e2e.ts
@@ -1,15 +1,15 @@
 // You can import and use all API from the 'vscode' module
-import * as vscode from "vscode";
+import * as assert from "assert";
 import * as path from "path";
+import * as vscode from "vscode";
 import {
     activateAndOpenInEditor,
-    getDocUri,
-    closeAllEditors,
     assertDiagnostics,
+    closeAllEditors,
     ensureGalaxyLanguageServerInstalled,
+    getDocUri,
     waitForDiagnostics,
 } from "./helpers";
-import * as assert from "assert";
 
 suite("Extension Test Suite", () => {
     suiteSetup(async () => {
@@ -81,6 +81,14 @@ suite("Extension Test Suite", () => {
             ]);
         });
 
+        test("Lint Valid tool returns no errors or warnings", async () => {
+            const docUri = getDocUri(path.join("validation/tool_02.xml"));
+            await activateAndOpenInEditor(docUri);
+
+            await waitForDiagnostics(docUri);
+            await assertDiagnostics(docUri, []);
+        });
+
         test("Linting valid tool with warnings should return warning diagnostics", async () => {
             const docUri = getDocUri(path.join("validation/tool_01.xml"));
             await activateAndOpenInEditor(docUri);
@@ -114,11 +122,6 @@ suite("Extension Test Suite", () => {
                 },
                 {
                     message: "No help section found, consider adding a help section to your tool.",
-                    range: new vscode.Range(new vscode.Position(0, 1), new vscode.Position(0, 5)),
-                    severity: vscode.DiagnosticSeverity.Warning,
-                },
-                {
-                    message: "Tool version [@TOOL_VERSION@+galaxy@VERSION_SUFFIX@] is not compliant with PEP 440.",
                     range: new vscode.Range(new vscode.Position(0, 1), new vscode.Position(0, 5)),
                     severity: vscode.DiagnosticSeverity.Warning,
                 },

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -30,7 +30,7 @@ from .utils import (
     convert_document_offsets_to_range,
 )
 
-MACRO_RELATED_TAGS = ["import", "token", "expand", "xml"]
+MACRO_RELATED_TAGS = ["import", "token", "macro", "xml", "expand"]
 
 
 class XmlDocument(XmlSyntaxNode):

--- a/server/galaxyls/services/xml/document.py
+++ b/server/galaxyls/services/xml/document.py
@@ -30,6 +30,8 @@ from .utils import (
     convert_document_offsets_to_range,
 )
 
+MACRO_RELATED_TAGS = ["import", "token", "expand", "xml"]
+
 
 class XmlDocument(XmlSyntaxNode):
     """Represents a parsed XML document.
@@ -80,7 +82,7 @@ class XmlDocument(XmlSyntaxNode):
             bool: True if the tool contains at least one <expand> elements.
         """
         try:
-            found = findall(self.root, filter_=lambda node: node.name == "expand", mincount=1)
+            found = findall(self.root, filter_=lambda node: node.name in MACRO_RELATED_TAGS, mincount=1)
             return len(found) > 0
         except BaseException:
             return False

--- a/server/galaxyls/tests/files/validation/tool_02.xml
+++ b/server/galaxyls/tests/files/validation/tool_02.xml
@@ -1,0 +1,35 @@
+<tool id="check_version" name="check_version" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
+    <macros>
+        <token name="@TOOL_VERSION@">3.7</token>
+        <token name="@GALAXY_VERSION@">0</token>
+    </macros>
+    <command detect_errors="exit_code"><![CDATA[
+    ]]></command>
+    <inputs>
+        <param name="input" type="text" format="txt" label="Input file"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" label="Output file"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="test"/>
+            <output name="output"/>
+        </test>
+    </tests>
+    <help><![CDATA[
+        The help text goes here.
+    ]]></help>
+    <citations>
+        <citation type="bibtex">
+            @article{cite1,
+                author = "Doe, J.",
+                title = "A really cool paper",
+                journal = "The Journal of Stuff",
+                volume = "1",
+                pages = "1-2",
+                year = "2023"
+            }
+        </citation>
+    </citations>
+</tool>

--- a/server/galaxyls/tests/unit/test_tools.py
+++ b/server/galaxyls/tests/unit/test_tools.py
@@ -110,6 +110,7 @@ class TestGalaxyToolXmlDocumentClass:
             ("<tool><token/></tool>", True),
             ("<tool><import/></tool>", True),
             ("<tool><xml/></tool>", True),
+            ("<tool><macro/></tool>", True),
         ],
     )
     def test_uses_macros_returns_expected(self, source: str, expected: bool) -> None:

--- a/server/galaxyls/tests/unit/test_tools.py
+++ b/server/galaxyls/tests/unit/test_tools.py
@@ -107,6 +107,9 @@ class TestGalaxyToolXmlDocumentClass:
             ("<tool><expand></tool>", True),
             ("<tool><expand></expand></tool>", True),
             ("<tool><expand/><expand/></tool>", True),
+            ("<tool><token/></tool>", True),
+            ("<tool><import/></tool>", True),
+            ("<tool><xml/></tool>", True),
         ],
     )
     def test_uses_macros_returns_expected(self, source: str, expected: bool) -> None:


### PR DESCRIPTION
Fixes #234

The expanded version of the tool source was only passed to the Galaxy linter when an `expand` tag was present in the unexpanded tool source. This change considers other macro-related tags to ensure the expanded version is linted when necessary.