### PR TITLE
Escape $ on non-snippet variables

### DIFF
--- a/client/src/snippets.json
+++ b/client/src/snippets.json
@@ -186,21 +186,21 @@
     "single output": {
         "prefix": "gx-output-single",
         "body": [
-            "<data name=\"$1\" format=\"$2\" label=\"${tool.name} on ${on_string}\" />"
+            "<data name=\"$1\" format=\"$2\" label=\"\\${tool.name} on \\${on_string}\" />"
         ],
         "description": "Add a simple single output."
     },
     "single output picked up from the working directory": {
         "prefix": "gx-output-single-from-work-dir",
         "body": [
-            "<data name=\"$1\" format=\"$2\" from_work_dir=\"$3\" label=\"${tool.name} on ${on_string}\" />"
+            "<data name=\"$1\" format=\"$2\" from_work_dir=\"$3\" label=\"\\${tool.name} on \\${on_string}\" />"
         ],
         "description": "Add a simple single output, that is picked up from the job working directory."
     },
     "single tabular output with column-metadata": {
         "prefix": "gx-output-single-tabular-with-metadata",
         "body": [
-            "<data name=\"$1\" format=\"tabular\" from_work_dir=\"$2\" label=\"${tool.name} on ${on_string}\">",
+            "<data name=\"$1\" format=\"tabular\" from_work_dir=\"$2\" label=\"\\${tool.name} on \\${on_string}\">",
             "    <actions>",
             "        <action name=\"column_names\" type=\"metadata\" default=\"$3,$4,$5\"/>",
             "    </actions>",
@@ -212,7 +212,7 @@
         "prefix": "gx-output-single-filter",
         "body": [
             "<!-- TODO: filters need to be adapted, see examples at https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-outputs-data-filter -->",
-            "<data name=\"$1\" format=\"$2\" from_work_dir=\"$3\" label=\"${tool.name} on ${on_string}\">",
+            "<data name=\"$1\" format=\"$2\" from_work_dir=\"$3\" label=\"\\${tool.name} on \\${on_string}\">",
             "    <filter>condintional_name['select_name'] == 'advanced' and conditional_name['boolean_parameter_name']</filter>",
             "</data>"
         ],
@@ -227,5 +227,5 @@
             "</collection>"
         ],
         "description": "Dynamic number of outputs in a collection."
-    }    
+    }
 }


### PR DESCRIPTION
Follow up on #233

The `$` character must be escaped to avoid VSCode confusing "snippet variables" with Galaxy variables.