### PR TITLE
Improve attribute with enum aut-completion

### DIFF
--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -225,11 +225,15 @@ class XmlCompletionService:
             CompletionItem: The completion item with the basic information
             about the attribute.
         """
+
+        value_placeholder = "$1"
+        if attr.enumeration:
+            value_placeholder = f"${{1|{','.join(attr.enumeration)}|}}"
         return CompletionItem(
             label=attr.name,
             kind=CompletionItemKind.Variable,
             documentation=attr.get_doc(),
-            insert_text=f'{attr.name}="$1"',
+            insert_text=f'{attr.name}="{value_placeholder}"',
             insert_text_format=InsertTextFormat.Snippet,
             sort_text=str(order).zfill(2),
         )


### PR DESCRIPTION
Closes #236 

When autocompleting attributes that define a set of valid values, the autocompletion snippet will directly offer a choice dropdown with those values instead of having to manually press `ctrl+space` to trigger the value completion.

![attr-enum-choices](https://github.com/galaxyproject/galaxy-language-server/assets/46503462/b6f79774-b04d-4975-9442-637ed474acc3)
