### PR TITLE
Relax LS version checking

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "lookpath": "^1.2.2",
+        "semver": "^7.5.4",
         "tmp": "^0.2.1",
         "vscode-languageclient": "^7.0.0"
       },
@@ -18,6 +19,7 @@
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.14.2",
+        "@types/semver": "^7.5.1",
         "@types/tmp": "^0.2.3",
         "@types/vscode": "^1.52.0",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
@@ -263,9 +265,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "node_modules/@types/tmp": {
@@ -2813,9 +2815,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3663,9 +3665,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "@types/tmp": {
@@ -5522,9 +5524,9 @@
       }
     },
     "semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -289,6 +289,7 @@
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.14.2",
+    "@types/semver": "^7.5.1",
     "@types/tmp": "^0.2.3",
     "@types/vscode": "^1.52.0",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
@@ -305,6 +306,7 @@
   "dependencies": {
     "iconv-lite": "^0.6.3",
     "lookpath": "^1.2.2",
+    "semver": "^7.5.4",
     "tmp": "^0.2.1",
     "vscode-languageclient": "^7.0.0"
   }

--- a/client/src/setup.ts
+++ b/client/src/setup.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "fs";
 import { join } from "path";
+import { gte } from "semver";
 import { commands, ExtensionContext, ProgressLocation, Uri, window, workspace } from "vscode";
 import { LocalStorageService } from "./configuration/storage";
 import { Constants } from "./constants";
@@ -218,8 +219,9 @@ async function isPythonPackageInstalled(python: string, packageName: string, ver
     try {
         const packageInfo = await execAsync(getPackageInfoCmd);
         const match = packageInfo.match(new RegExp(pattern));
+        const installedVersion = match?.groups?.version ?? "0.0.0";
         console.log(`[gls] Version found: ${packageName} - ${match?.groups?.version}`);
-        return version === match?.groups?.version;
+        return gte(installedVersion, version);
     } catch (err: any) {
         console.error(`[gls] isPythonPackageInstalled err: ${err}`);
         return false;


### PR DESCRIPTION
If there is a more recent version of the GLS already installed, do not downgrade to the old version as the recent version should be compatible and contain additional fixes.

This also plays more nicely with CI end-to-end tests as (since #232) the latest dev version of the LS is installed.