### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 21
       - run: npm install
       - name: Run integration tests
         run: xvfb-run -a npm run test:e2e

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python for local environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,21 @@ jobs:
         id: get_version
         uses: jannemattila/get-version-from-tag@v3
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 21
+
+      - run: npm ci
+
+      - name: Package Extension
+        id: packageExtension
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: stub
+          packagePath: "./client/"
+          dryRun: true
+
       - name: Create Draf Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -43,9 +58,11 @@ jobs:
           draft: true
           prerelease: false
           generate_release_notes: true
+          files: ${{ steps.packageExtension.outputs.vsixPath }}
     outputs:
       release_version: ${{ steps.get_version.outputs.version }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
+      vsixPath: ${{ steps.packageExtension.outputs.vsixPath }}
 
   publish-server:
     name: Publish Language Server to PyPI
@@ -92,10 +109,6 @@ jobs:
         with:
           node-version: 21
 
-      - name: Clean install dependencies
-        run: |
-          npm ci
-
       - name: Update version in package.json
         uses: onlyutkarsh/patch-files-action@v1.0.5
         with:
@@ -103,34 +116,16 @@ jobs:
           patch-syntax: |
             = /version => "${{needs.prepare_release.outputs.release_version}}"
 
-      - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v1
-        id: publishToOpenVSX
-        with:
-          pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          packagePath: "./client/"
-
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
-          packagePath: ""
+          extensionFile: ${{ needs.prepare_release.outputs.vsixPath}}
 
-      - name: Upload vsix as artifact
-        uses: actions/upload-artifact@v3
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        id: publishToOpenVSX
         with:
-          name: galaxy-tools-${{needs.prepare_release.outputs.release_version}}.vsix
-          path: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.release_upload_url }}
-          asset_path: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
-          asset_name: galaxy-tools-${{needs.prepare_release.outputs.release_version}}.vsix
-          asset_content_type: application/vsix
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ${{ needs.prepare_release.outputs.vsixPath}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,11 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           body: |
             This release contains the [Galaxy Language Server](https://github.com/davelopez/galaxy-language-server/tree/main/server) and the [Galaxy Tools Visual Studio Code Extension](https://github.com/davelopez/galaxy-language-server/tree/main/client).
             You can view the list of changes in the respective changelogs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   prepare_release:
-    name: Create Release
+    name: Prepare Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -20,7 +20,7 @@ jobs:
         id: get_version
         uses: jannemattila/get-version-from-tag@v3
 
-      - name: Create Release
+      - name: Create Draf Release
         id: create_release
         uses: softprops/action-gh-release@v2
         env:
@@ -40,8 +40,9 @@ jobs:
             ```
             code --install-extension galaxy-tools-${{ steps.get_version.outputs.version }}.vsix
             ```
-          draft: false
+          draft: true
           prerelease: false
+          generate_release_notes: true
     outputs:
       release_version: ${{ steps.get_version.outputs.version }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get version from tag
         id: get_version
-        uses: battila7/get-version-action@v2
+        uses: jannemattila/get-version-from-tag@v3
 
       - name: Create Release
         id: create_release
@@ -39,12 +39,12 @@ jobs:
             The Galaxy Tools Extension is available at [Open VSX Registry](https://open-vsx.org/extension/davelopez/galaxy-tools) and [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=davelopez.galaxy-tools).
             You can also install the extension manually by downloading the VSIX package included in this release and using:
             ```
-            code --install-extension galaxy-tools-${{ steps.get_version.outputs.version-without-v }}.vsix
+            code --install-extension galaxy-tools-${{ steps.get_version.outputs.version }}.vsix
             ```
           draft: false
           prerelease: false
     outputs:
-      release_version: ${{ steps.get_version.outputs.version-without-v }}
+      release_version: ${{ steps.get_version.outputs.version }}
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
 
   publish-server:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get version from tag
         id: get_version
@@ -56,10 +56,10 @@ jobs:
         working-directory: server
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 
@@ -85,10 +85,10 @@ jobs:
         working-directory: client
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,13 +109,6 @@ jobs:
         with:
           node-version: 21
 
-      - name: Update version in package.json
-        uses: onlyutkarsh/patch-files-action@v1.0.5
-        with:
-          files: "${{github.workspace}}/client/package.json"
-          patch-syntax: |
-            = /version => "${{needs.prepare_release.outputs.release_version}}"
-
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 21
 
       - name: Clean install dependencies
         run: |

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -20,9 +20,9 @@ jobs:
         working-directory: server
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Replace some deprecated GitHub workflow actions with new ones and simplify the release workflow to reuse the same VSIX package.