### PR TITLE
Add feature Insert param reference/output filter

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -132,11 +132,18 @@
         "category": "Galaxy Tools",
         "enablement": "galaxytools:isActive",
         "icon": "$(open-preview)"
-      }
-      ,
+      },
       {
         "command": "galaxytools.insert.paramReference",
         "title": "Insert a reference to a param element.",
+        "category": "Galaxy Tools",
+        "enablement": "galaxytools:isActive",
+        "icon": "$(insert)",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "galaxytools.insert.paramFilterReference",
+        "title": "Insert a reference to a param element to be used as output filter.",
         "category": "Galaxy Tools",
         "enablement": "galaxytools:isActive",
         "icon": "$(insert)",
@@ -168,6 +175,11 @@
         "command": "galaxytools.insert.paramReference",
         "key": "ctrl+alt+i ctrl+alt+p",
         "mac": "cmd+alt+i cmd+alt+p"
+      },
+      {
+        "command": "galaxytools.insert.paramFilterReference",
+        "key": "ctrl+alt+i ctrl+alt+f",
+        "mac": "cmd+alt+i cmd+alt+f"
       }
     ],
     "configuration": {

--- a/client/package.json
+++ b/client/package.json
@@ -133,6 +133,15 @@
         "enablement": "galaxytools:isActive",
         "icon": "$(open-preview)"
       }
+      ,
+      {
+        "command": "galaxytools.insert.paramReference",
+        "title": "Insert a reference to a param element.",
+        "category": "Galaxy Tools",
+        "enablement": "galaxytools:isActive",
+        "icon": "$(insert)",
+        "when": "editorTextFocus"
+      }
     ],
     "keybindings": [
       {
@@ -154,6 +163,11 @@
         "command": "galaxytools.sort.documentParamsAttributes",
         "key": "ctrl+alt+s ctrl+alt+d",
         "mac": "cmd+alt+s cmd+alt+d"
+      },
+      {
+        "command": "galaxytools.insert.paramReference",
+        "key": "ctrl+alt+i ctrl+alt+p",
+        "mac": "cmd+alt+i cmd+alt+p"
       }
     ],
     "configuration": {

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -33,6 +33,7 @@ export namespace Commands {
     export const OPEN_TERMINAL_AT_DIRECTORY_ITEM: ICommand = getCommands("openTerminalAtDirectory");
     export const GENERATE_EXPANDED_DOCUMENT: ICommand = getCommands("generate.expandedDocument");
     export const PREVIEW_EXPANDED_DOCUMENT: ICommand = getCommands("preview.expandedDocument");
+    export const INSERT_PARAM_REFERENCE: ICommand = getCommands("insert.paramReference");
 }
 
 interface GeneratedSnippetResult {
@@ -45,6 +46,10 @@ interface GeneratedSnippetResult {
 interface ReplaceTextRangeResult {
     text: string;
     replace_range: Range;
+}
+
+interface ParamReferencesResult {
+    references: string[];
 }
 
 export interface GeneratedExpandedDocument {
@@ -64,6 +69,8 @@ export function setupCommands(client: LanguageClient, context: ExtensionContext)
     setupSortDocumentParams(client, context);
 
     setupGenerateExpandedDocument(client, context);
+
+    setupInsertParamReference(client, context);
 
     context.subscriptions.push(
         commands.registerCommand(Commands.PREVIEW_EXPANDED_DOCUMENT.internal, previewExpandedDocument)
@@ -119,6 +126,13 @@ function setupGenerateTestCases(client: LanguageClient, context: ExtensionContex
         requestInsertSnippet(client, Commands.GENERATE_TEST.external);
     };
     context.subscriptions.push(commands.registerCommand(Commands.GENERATE_TEST.internal, generateTest));
+}
+
+function setupInsertParamReference(client: LanguageClient, context: ExtensionContext) {
+    const insertParamReferenceHandler = async () => {
+        pickParamReferenceToInsert(client, Commands.INSERT_PARAM_REFERENCE.external);
+    };
+    context.subscriptions.push(commands.registerCommand(Commands.INSERT_PARAM_REFERENCE.internal, insertParamReferenceHandler));
 }
 
 function setupAutoCloseTags(client: LanguageClient, context: ExtensionContext) {
@@ -207,6 +221,30 @@ async function requestInsertSnippet(client: LanguageClient, command: string) {
             const position = new Position(response.position.line, response.position.character);
             activeEditor.insertSnippet(snippet, position);
         }
+    } catch (err: any) {
+        window.showErrorMessage(err);
+    }
+}
+
+async function pickParamReferenceToInsert(client: LanguageClient, command: string) {
+    const activeEditor = window.activeTextEditor;
+    if (!activeEditor) return;
+
+    const document = activeEditor.document;
+
+    const param = client.code2ProtocolConverter.asTextDocumentIdentifier(document);
+    const response = await commands.executeCommand<ParamReferencesResult>(command, param);
+    if (!response || !response.references || response.references.length === 0) {
+        return;
+    }
+
+    try {
+        const selected = await window.showQuickPick(response.references, { title: "Select a parameter reference to insert" });
+        if (!selected) return;
+
+        activeEditor.edit(editBuilder => {
+            editBuilder.insert(activeEditor.selection.active, selected);
+        });
     } catch (err: any) {
         window.showErrorMessage(err);
     }

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -34,6 +34,7 @@ export namespace Commands {
     export const GENERATE_EXPANDED_DOCUMENT: ICommand = getCommands("generate.expandedDocument");
     export const PREVIEW_EXPANDED_DOCUMENT: ICommand = getCommands("preview.expandedDocument");
     export const INSERT_PARAM_REFERENCE: ICommand = getCommands("insert.paramReference");
+    export const INSERT_PARAM_FILTER_REFERENCE: ICommand = getCommands("insert.paramFilterReference");
 }
 
 interface GeneratedSnippetResult {
@@ -129,10 +130,12 @@ function setupGenerateTestCases(client: LanguageClient, context: ExtensionContex
 }
 
 function setupInsertParamReference(client: LanguageClient, context: ExtensionContext) {
-    const insertParamReferenceHandler = async () => {
+    context.subscriptions.push(commands.registerCommand(Commands.INSERT_PARAM_REFERENCE.internal, () => {
         pickParamReferenceToInsert(client, Commands.INSERT_PARAM_REFERENCE.external);
-    };
-    context.subscriptions.push(commands.registerCommand(Commands.INSERT_PARAM_REFERENCE.internal, insertParamReferenceHandler));
+    }));
+    context.subscriptions.push(commands.registerCommand(Commands.INSERT_PARAM_FILTER_REFERENCE.internal, () => {
+        pickParamReferenceToInsert(client, Commands.INSERT_PARAM_FILTER_REFERENCE.external);
+    }))
 }
 
 function setupAutoCloseTags(client: LanguageClient, context: ExtensionContext) {
@@ -226,7 +229,7 @@ async function requestInsertSnippet(client: LanguageClient, command: string) {
     }
 }
 
-async function pickParamReferenceToInsert(client: LanguageClient, command: string) {
+async function pickParamReferenceToInsert(client: LanguageClient, command: string, pickerTitle: string = "Select a parameter reference to insert") {
     const activeEditor = window.activeTextEditor;
     if (!activeEditor) return;
 
@@ -239,7 +242,7 @@ async function pickParamReferenceToInsert(client: LanguageClient, command: strin
     }
 
     try {
-        const selected = await window.showQuickPick(response.references, { title: "Select a parameter reference to insert" });
+        const selected = await window.showQuickPick(response.references, { title: pickerTitle });
         if (!selected) return;
 
         activeEditor.edit(editBuilder => {

--- a/server/galaxyls/constants.py
+++ b/server/galaxyls/constants.py
@@ -16,6 +16,7 @@ class Commands:
     DISCOVER_TESTS_IN_DOCUMENT = "gls.tests.discoverInDocument"
     GENERATE_EXPANDED_DOCUMENT = "gls.generate.expandedDocument"
     INSERT_PARAM_REFERENCE = "gls.insert.paramReference"
+    INSERT_PARAM_FILTER_REFERENCE = "gls.insert.paramFilterReference"
 
 
 class DiagnosticCodes:

--- a/server/galaxyls/constants.py
+++ b/server/galaxyls/constants.py
@@ -15,6 +15,7 @@ class Commands:
     DISCOVER_TESTS_IN_WORKSPACE = "gls.tests.discoverInWorkspace"
     DISCOVER_TESTS_IN_DOCUMENT = "gls.tests.discoverInDocument"
     GENERATE_EXPANDED_DOCUMENT = "gls.generate.expandedDocument"
+    INSERT_PARAM_REFERENCE = "gls.insert.paramReference"
 
 
 class DiagnosticCodes:

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -303,12 +303,25 @@ def discover_tests_in_document_command(
 async def cmd_insert_param_reference(
     server: GalaxyToolsLanguageServer, parameters: CommandParameters
 ) -> Optional[ParamReferencesResult]:
-    """Provides a list of possible parameter references to be inserted in the document."""
+    """Provides a list of possible parameter references to be inserted in the command section of the document."""
     params = convert_to(parameters[0], TextDocumentIdentifier)
     document = _get_valid_document(server, params.uri)
     if document:
         xml_document = _get_xml_document(document)
         return server.service.param_references_provider.get_param_command_references(xml_document)
+    return None
+
+
+@language_server.command(Commands.INSERT_PARAM_FILTER_REFERENCE)
+async def cmd_insert_param_filter_reference(
+    server: GalaxyToolsLanguageServer, parameters: CommandParameters
+) -> Optional[ParamReferencesResult]:
+    """Provides a list of possible parameter references to be inserted as output filters."""
+    params = convert_to(parameters[0], TextDocumentIdentifier)
+    document = _get_valid_document(server, params.uri)
+    if document:
+        xml_document = _get_xml_document(document)
+        return server.service.param_references_provider.get_param_filter_references(xml_document)
     return None
 
 

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -308,7 +308,7 @@ async def cmd_insert_param_reference(
     document = _get_valid_document(server, params.uri)
     if document:
         xml_document = _get_xml_document(document)
-        return server.service.param_references_provider.get_param_references(xml_document)
+        return server.service.param_references_provider.get_param_command_references(xml_document)
     return None
 
 

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -56,6 +56,7 @@ from galaxyls.types import (
     CommandParameters,
     GeneratedExpandedDocument,
     GeneratedSnippetResult,
+    ParamReferencesResult,
     ReplaceTextRangeResult,
     TestSuiteInfoResult,
 )
@@ -295,6 +296,19 @@ def discover_tests_in_document_command(
     if document:
         xml_document = _get_xml_document(document)
         return server.service.test_discovery_service.discover_tests_in_document(xml_document)
+    return None
+
+
+@language_server.command(Commands.INSERT_PARAM_REFERENCE)
+async def cmd_insert_param_reference(
+    server: GalaxyToolsLanguageServer, parameters: CommandParameters
+) -> Optional[ParamReferencesResult]:
+    """Provides a list of possible parameter references to be inserted in the document."""
+    params = convert_to(parameters[0], TextDocumentIdentifier)
+    document = _get_valid_document(server, params.uri)
+    if document:
+        xml_document = _get_xml_document(document)
+        return server.service.param_references_provider.get_param_references(xml_document)
     return None
 
 

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -26,6 +26,7 @@ from pygls.workspace import (
 from galaxyls.services.definitions import DocumentDefinitionsProvider
 from galaxyls.services.links import DocumentLinksProvider
 from galaxyls.services.macros import MacroExpanderService
+from galaxyls.services.references import ParamReferencesProvider
 from galaxyls.services.symbols import DocumentSymbolsProvider
 from galaxyls.services.tools.common import (
     TestsDiscoveryService,
@@ -78,6 +79,7 @@ class GalaxyToolLanguageService:
         self.definitions_provider: Optional[DocumentDefinitionsProvider] = None
         self.link_provider = DocumentLinksProvider()
         self.symbols_provider = DocumentSymbolsProvider()
+        self.param_references_provider = ParamReferencesProvider()
 
     def set_workspace(self, workspace: Workspace) -> None:
         macro_definitions_provider = MacroDefinitionsProvider(workspace)

--- a/server/galaxyls/services/references.py
+++ b/server/galaxyls/services/references.py
@@ -1,0 +1,51 @@
+from typing import Optional
+
+from galaxyls.services.tools.document import GalaxyToolXmlDocument
+from galaxyls.services.xml.document import XmlDocument
+from galaxyls.services.xml.nodes import XmlElement
+from galaxyls.types import ParamReferencesResult
+
+
+class ParamReferencesProvider:
+    def get_param_references(self, xml_document: XmlDocument) -> Optional[ParamReferencesResult]:
+        # TODO: Should work with expanded documents
+
+        tool = GalaxyToolXmlDocument.from_xml_document(xml_document)
+        references = []
+        params = tool.get_input_params()
+        for param in params:
+            reference = self._build_reference(param)
+            if reference:
+                references.append(reference)
+
+        return ParamReferencesResult(references)
+
+    def _build_reference(self, param: XmlElement) -> Optional[str]:
+        reference = None
+        # The reference should be a string with the path to the param separated by dots and starting with a $
+        # Skip the first 3 ancestors (document root, tool, inputs) to start at the input element.
+        ancestors = param.ancestors[3:]
+        path = []
+        for ancestor in ancestors:
+            name = ancestor.get_attribute_value("name")
+            if name:
+                path.append(name)
+        name = self._get_param_name(param)
+        if name:
+            path.append(name)
+        if path:
+            reference = f"${'.'.join(path)}"
+        return reference
+
+    def _get_param_name(self, param: XmlElement) -> Optional[str]:
+        name = param.get_attribute_value("name")
+        if not name:
+            name = param.get_attribute_value("argument")
+            if name:
+                return self._normalize_argument_name(name)
+        return name
+
+    def _normalize_argument_name(self, argument: str) -> str:
+        if argument.startswith("--"):
+            argument = argument[2:]
+        return argument.replace("-", "_")

--- a/server/galaxyls/services/references.py
+++ b/server/galaxyls/services/references.py
@@ -8,9 +8,7 @@ from galaxyls.types import ParamReferencesResult
 
 class ParamReferencesProvider:
     def get_param_references(self, xml_document: XmlDocument) -> Optional[ParamReferencesResult]:
-        # TODO: Should work with expanded documents
-
-        tool = GalaxyToolXmlDocument.from_xml_document(xml_document)
+        tool = GalaxyToolXmlDocument.from_xml_document(xml_document).get_expanded_tool_document()
         references = []
         params = tool.get_input_params()
         for param in params:

--- a/server/galaxyls/services/references.py
+++ b/server/galaxyls/services/references.py
@@ -13,7 +13,18 @@ class ParamReferencesProvider:
         references = []
         params = tool.get_input_params()
         for param in params:
-            reference = self._build_reference(param)
+            reference = self._build_command_reference(param)
+            if reference:
+                references.append(reference)
+        return ParamReferencesResult(references)
+
+    def get_param_filter_references(self, xml_document: XmlDocument) -> Optional[ParamReferencesResult]:
+        """Returns a list of references for the input parameters of the tool that can be used in output filters."""
+        tool = GalaxyToolXmlDocument.from_xml_document(xml_document).get_expanded_tool_document()
+        references = []
+        params = tool.get_input_params()
+        for param in params:
+            reference = self._build_filter_reference(param)
             if reference:
                 references.append(reference)
         return ParamReferencesResult(references)
@@ -44,9 +55,18 @@ class ParamReferencesProvider:
             argument = argument[2:]
         return argument.replace("-", "_")
 
-    def _build_reference(self, param: XmlElement) -> Optional[str]:
+    def _build_command_reference(self, param: XmlElement) -> Optional[str]:
         reference = None
         path = self.get_param_path(param)
         if path:
             reference = f"${'.'.join(path)}"
+        return reference
+
+    def _build_filter_reference(self, param: XmlElement) -> Optional[str]:
+        reference = None
+        path = self.get_param_path(param)
+        if path:
+            reference = path[0]
+            for elem in path[1:]:
+                reference += f"['{elem}']"
         return reference

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -169,6 +169,17 @@ class GalaxyToolXmlDocument:
             return outputs.elements
         return []
 
+    def get_input_params(self) -> List[XmlElement]:
+        """Gets the input params of this document as a list of elements.
+
+        Returns:
+            List[XmlElement]: The params defined in the document.
+        """
+        inputs = self.find_element(INPUTS)
+        if inputs:
+            return inputs.get_recursive_descendants_with_name("param")
+        return []
+
     def get_tool_element(self) -> Optional[XmlElement]:
         """Gets the root tool element"""
         return self.find_element(TOOL)

--- a/server/galaxyls/services/tools/document.py
+++ b/server/galaxyls/services/tools/document.py
@@ -7,10 +7,12 @@ from typing import (
 )
 
 from anytree import find  # type: ignore
+from galaxy.util import xml_macros
 from lsprotocol.types import (
     Position,
     Range,
 )
+from lxml import etree
 from pygls.workspace import Document
 
 from galaxyls.services.tools.constants import (
@@ -227,6 +229,22 @@ class GalaxyToolXmlDocument:
                     if imp_filename == filename:
                         return self.xml_document.get_full_range(imp)
         return None
+
+    def get_expanded_tool_document(self) -> "GalaxyToolXmlDocument":
+        """If the given tool document uses macros, a new tool document with the expanded macros is returned,
+        otherwise, the same document is returned.
+        """
+        if self.uses_macros:
+            try:
+                document = self.document
+                expanded_tool_tree, _ = xml_macros.load_with_references(document.path)
+                expanded_tool_tree = cast(etree._ElementTree, expanded_tool_tree)  # type: ignore
+                expanded_source = etree.tostring(expanded_tool_tree, encoding=str)
+                expanded_document = Document(uri=document.uri, source=expanded_source, version=document.version)
+                return GalaxyToolXmlDocument(expanded_document)
+            except BaseException:
+                return self
+        return self
 
     def get_tool_id(self) -> Optional[str]:
         """Gets the identifier of the tool"""

--- a/server/galaxyls/services/tools/generators/snippets.py
+++ b/server/galaxyls/services/tools/generators/snippets.py
@@ -10,13 +10,10 @@ from typing import (
     cast,
 )
 
-from galaxy.util import xml_macros
 from lsprotocol.types import (
     Position,
     Range,
 )
-from lxml import etree
-from pygls.workspace import Document
 
 from galaxyls.services.tools.constants import (
     DASH,
@@ -32,7 +29,7 @@ class SnippetGenerator(ABC):
 
     def __init__(self, tool_document: GalaxyToolXmlDocument, tabSize: int = 4) -> None:
         self.tool_document = tool_document
-        self.expanded_document = self._get_expanded_tool_document(tool_document)
+        self.expanded_document = tool_document.get_expanded_tool_document()
         self.tabstop_count: int = 0
         self.indent_spaces: str = " " * tabSize
         super().__init__()
@@ -62,22 +59,6 @@ class SnippetGenerator(ABC):
         """This abstract function should find the proper position inside the document where the
         snippet will be inserted."""
         pass
-
-    def _get_expanded_tool_document(self, tool_document: GalaxyToolXmlDocument) -> GalaxyToolXmlDocument:
-        """If the given tool document uses macros, a new tool document with the expanded macros is returned,
-        otherwise, the same document is returned.
-        """
-        if tool_document.uses_macros:
-            try:
-                document = tool_document.document
-                expanded_tool_tree, _ = xml_macros.load_with_references(document.path)
-                expanded_tool_tree = cast(etree._ElementTree, expanded_tool_tree)  # type: ignore
-                expanded_source = etree.tostring(expanded_tool_tree, encoding=str)
-                expanded_document = Document(uri=document.uri, source=expanded_source, version=document.version)
-                return GalaxyToolXmlDocument(expanded_document)
-            except BaseException:
-                return tool_document
-        return tool_document
 
     def _get_next_tabstop(self) -> str:
         """Increments the tabstop count and returns the current tabstop

--- a/server/galaxyls/services/xml/nodes.py
+++ b/server/galaxyls/services/xml/nodes.py
@@ -421,6 +421,15 @@ class XmlElement(XmlContainerNode):
         children = [child for child in self.children if child.name == name]
         return list(children)
 
+    def get_recursive_descendants_with_name(self, name: str) -> List["XmlElement"]:
+        descendants = []
+        for child in self.children:
+            if child.name == name:
+                descendants.append(child)
+            if isinstance(child, XmlElement):
+                descendants.extend(child.get_recursive_descendants_with_name(name))
+        return descendants
+
     def get_cdata_section(self) -> Optional["XmlCDATASection"]:
         """Gets the CDATA node inside this element or None if it doesn't have a CDATA section."""
         return next((node for node in self.children if type(node) is XmlCDATASection), None)

--- a/server/galaxyls/types.py
+++ b/server/galaxyls/types.py
@@ -88,3 +88,13 @@ class GeneratedExpandedDocument:
 
     content: Optional[str] = attrs.field(default=None)
     error_message: Optional[str] = attrs.field(default=None, alias="errorMessage")
+
+
+class ParamReferencesResult:
+    """Contains information about the references to a parameter in the document."""
+
+    def __init__(
+        self,
+        references: List[str],
+    ) -> None:
+        self.references = references


### PR DESCRIPTION
fixes #262

This PR adds two new custom commands.

One for picking a `param` reference and then inserting it at the current cursor position. 

![ToolInsertParamRef](https://github.com/user-attachments/assets/381b5288-423f-42f1-9e3b-b4c2c958fc03)

And the other one does a similar thing but creates "dictionary access like" references to be used, for example, in output filters.

![image](https://github.com/user-attachments/assets/5fe9ab43-c532-4eeb-81d2-9ce2f057b31e)


You can invoke these commands using the Command Palette (ctrl+shift+p) and then searching for Galaxy Tools... or by using the default keyboard shortcuts, `ctrl+alt+i+p` (for insert param reference) and `ctrl+alt+i+f` for inserting the filter version of the reference. Remember that you can always customize your [key bindings](https://code.visualstudio.com/docs/getstarted/keybindings).