### PR TITLE
Refactor `Release` GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,15 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  prepare_release:
-    name: Prepare Release
+  release:
+    name: Publish Release
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # --- Prepare and Package Client ---
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -25,7 +27,7 @@ jobs:
         working-directory: ./client
         run: npm i
 
-      - name: Package Extension
+      - name: Package VS Code Extension
         id: packageExtension
         uses: HaaLeo/publish-vscode-extension@v2
         with:
@@ -33,6 +35,23 @@ jobs:
           packagePath: "./client/"
           dryRun: true
 
+      # --- Prepare and Package Server ---
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+
+      - name: Install Python packaging tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+        working-directory: server
+
+      - name: Package Python Server
+        run: python setup.py sdist bdist_wheel
+        working-directory: server
+
+      # --- Create GitHub Release ---
       - name: Create Draft Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -41,77 +60,41 @@ jobs:
         with:
           name: Release ${{ github.ref }}
           body: |
-            This release contains the [Galaxy Language Server](https://github.com/davelopez/galaxy-language-server/tree/main/server) and the [Galaxy Tools Visual Studio Code Extension](https://github.com/davelopez/galaxy-language-server/tree/main/client).
-            You can view the list of changes in the respective changelogs:
-            - Galaxy Language Server [changelog](https://github.com/davelopez/galaxy-language-server/blob/main/server/CHANGELOG.md)
-            - Galaxy Tools Visual Studio Extension [changelog](https://github.com/davelopez/galaxy-language-server/blob/main/client/CHANGELOG.md#)
+            This release contains:
+            - [Galaxy Language Server](https://github.com/davelopez/galaxy-language-server/tree/main/server)
+            - [Galaxy Tools VS Code Extension](https://github.com/davelopez/galaxy-language-server/tree/main/client)
 
-            The standalone version of the language server is available as a [PyPI package](https://pypi.org/project/galaxy-language-server/).
+            Changelog links:
+            - [Galaxy Language Server](https://github.com/davelopez/galaxy-language-server/blob/main/server/CHANGELOG.md)
+            - [Galaxy Tools Extension](https://github.com/davelopez/galaxy-language-server/blob/main/client/CHANGELOG.md#)
 
-            The Galaxy Tools Extension is available at [Open VSX Registry](https://open-vsx.org/extension/davelopez/galaxy-tools) and [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=davelopez.galaxy-tools).
+            The standalone language server is available on [PyPI](https://pypi.org/project/galaxy-language-server/).
+            The VS Code extension is available on [Open VSX](https://open-vsx.org/extension/davelopez/galaxy-tools) and [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=davelopez.galaxy-tools).
           draft: true
           prerelease: false
           generate_release_notes: true
-          files: ${{ steps.packageExtension.outputs.vsixPath }}
-    outputs:
-      release_upload_url: ${{ steps.create_release.outputs.upload_url }}
-      vsixPath: ${{ steps.packageExtension.outputs.vsixPath }}
+          files: |
+            server/dist/*
+            ${{ steps.packageExtension.outputs.vsixPath }}
 
-  publish-server:
-    name: Publish Language Server to PyPI
-    needs: prepare_release
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: server
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.8
-
-      - name: Install Tools
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-
-      - name: Package and Upload to PyPI
+      # --- Publish Python Package to PyPI ---
+      - name: Upload Python package to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload --skip-existing dist/*
+        run: twine upload --skip-existing dist/*
+        working-directory: server
 
-  publish-client:
-    name: Publish extension to Open-VSX and VSCode Marketplace
-    needs: prepare_release
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: client
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
+      # --- Publish VS Code Extension ---
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ needs.prepare_release.outputs.vsixPath }}
+          extensionFile: ${{ steps.packageExtension.outputs.vsixPath }}
 
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v2
-        id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: ${{ needs.prepare_release.outputs.vsixPath }}
+          extensionFile: ${{ steps.packageExtension.outputs.vsixPath }}


### PR DESCRIPTION
By merging everything into a single release job, we avoid workspace resets, simplify file handling, and ensure everything is executed in the correct order. This should eliminate the ENOENT issue and, hopefully, make the workflow more reliable in future releases.