### PR TITLE
Add Code Actions to tokenize a tool version into @TOOL_VERSION@/@VERSION_SUFFIX@

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Galaxy Language Server Changelog
 
+## [Unreleased]
+
+### Added
+
+- Add **Code Actions** to factor a literal tool `version` into `@TOOL_VERSION@` / `@VERSION_SUFFIX@` tokens (the IUC "Tool versions" practice), either inline or in a new imported `macros.xml`. Offered on a `<tool>` whose version is provably tokenizable; kept only when the macro expansion is byte-identical. Backed by the optional [`galaxy-tool-source`](https://pypi.org/project/galaxy-tool-source/) engine, which self-registers only when installed.
+
 ## [0.15.0] - 2026-02-16
 
 ### Changed

--- a/server/galaxyls/server.py
+++ b/server/galaxyls/server.py
@@ -189,6 +189,7 @@ def document_link(server: GalaxyToolsLanguageServer, params: DocumentLinkParams)
     CodeActionOptions(
         code_action_kinds=[
             CodeActionKind.RefactorExtract,
+            CodeActionKind.RefactorRewrite,
         ],
     ),
 )

--- a/server/galaxyls/services/language.py
+++ b/server/galaxyls/services/language.py
@@ -37,6 +37,17 @@ from galaxyls.services.tools.refactor import (
     RefactoringService,
     RefactorMacrosService,
 )
+
+try:
+    # Optional: the version-tokenization engine (galaxy-tool-source). The Code Action
+    # self-registers only when the engine is importable, so the server still works
+    # without it installed.
+    from galaxyls.services.tools.version_tokenize import VersionTokenizeService
+
+    VERSION_TOKENIZE_AVAILABLE = True
+except ImportError:
+    VersionTokenizeService = None  # type: ignore[assignment, misc]
+    VERSION_TOKENIZE_AVAILABLE = False
 from galaxyls.services.tools.testing import ToolTestsDiscoveryService
 
 from ..config import CompletionMode
@@ -82,7 +93,8 @@ class GalaxyToolLanguageService:
         self.definitions_provider = DocumentDefinitionsProvider(macro_definitions_provider)
         self.completion_service = XmlCompletionService(self.xsd_tree, self.definitions_provider)
         self.refactoring_service = RefactoringService(
-            RefactorMacrosService(workspace, macro_definitions_provider, self.format_service)
+            RefactorMacrosService(workspace, macro_definitions_provider, self.format_service),
+            VersionTokenizeService() if VersionTokenizeService is not None else None,
         )
 
     def get_diagnostics(self, xml_document: XmlDocument) -> list[Diagnostic]:

--- a/server/galaxyls/services/tools/refactor.py
+++ b/server/galaxyls/services/tools/refactor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import attrs
@@ -37,6 +38,9 @@ from galaxyls.services.tools.macros import (
 )
 from galaxyls.services.xml.document import XmlDocument
 from galaxyls.services.xml.nodes import XmlElement
+
+if TYPE_CHECKING:
+    from galaxyls.services.tools.version_tokenize import VersionTokenizeService
 
 DEFAULT_MACROS_FILENAME = "macros.xml"
 EXCLUDED_TAGS = {TOOL, MACROS, MACRO, XML}
@@ -282,12 +286,21 @@ class RefactorMacrosService:
 
 
 class RefactoringService:
-    def __init__(self, macros_refactoring_service: RefactorMacrosService) -> None:
+    def __init__(
+        self,
+        macros_refactoring_service: RefactorMacrosService,
+        version_tokenize_service: "VersionTokenizeService | None" = None,
+    ) -> None:
         self.macros = macros_refactoring_service
+        # Optional: the version-tokenization engine (galaxy-tool-source), wired in only
+        # when importable (the same gate as the rename engine).
+        self.version_tokenize = version_tokenize_service
 
     def get_available_refactoring_actions(self, xml_document: XmlDocument, params: CodeActionParams) -> list[CodeAction]:
         """Gets a collection of possible refactoring code actions on a selected chunk of the document."""
         code_actions = []
+        if self.version_tokenize is not None:
+            code_actions.extend(self.version_tokenize.create_version_tokenize_actions(xml_document, params))
         text_in_range = xml_document.get_text_in_range(params.range)
         target_element_tag = self._get_valid_full_element_tag(text_in_range)
         if target_element_tag is not None:

--- a/server/galaxyls/services/tools/version_tokenize.py
+++ b/server/galaxyls/services/tools/version_tokenize.py
@@ -1,0 +1,141 @@
+"""Code Action: factor a tool's literal version into @TOOL_VERSION@/@VERSION_SUFFIX@.
+
+This binds the offset-returning version-tokenization planner from ``galaxy_tool_source``
+(``tokenize_version_plan``, which returns minimal ``(start, end, replacement)`` edits over
+the original source plus, in separate-file mode, the full content of a new ``macros.xml``)
+to an LSP ``textDocument/codeAction``. It is the version-tokenization sibling of the
+parameter-rename binding (``rename.py``): the engine owns the soundness, kept only when the
+tokenization macro-expands byte-identically to the original (the IUC "Tool versions"
+practice), so this layer is offset/``Range`` conversion plus ``WorkspaceEdit`` assembly.
+
+Two actions are offered when the cursor is on the ``<tool …>`` start tag of a tool the
+engine reports as a candidate (a literal ``version="<base>+galaxy<suffix>"`` whose base
+matches a package ``<requirement>``):
+
+- **Define version tokens** — define the two ``<token>``s in an inline ``<macros>`` block
+  (a single-document ``WorkspaceEdit`` of minimal ``TextEdit``s).
+- **Extract version tokens to macros.xml** — define them in a new imported ``macros.xml``
+  (a multi-document ``WorkspaceEdit``: a ``CreateFile`` resource operation plus the new
+  file's content, plus the ``<import>`` and token references in the tool). This reuses the
+  ``CreateFile`` shape of the extract-to-macros-file refactor (``refactor.py``).
+
+The document's filesystem path is passed to the planner as ``source_path`` so its
+expansion-equality gate can resolve the tool's own ``<import>``ed macro files; a tool with
+unresolved imports simply yields no action (the planner fails closed).
+"""
+
+from pathlib import Path
+
+from galaxy_tool_source.version_tokens import VersionTokenPlan, tokenize_version_plan
+from lsprotocol.types import (
+    CodeAction,
+    CodeActionKind,
+    CodeActionParams,
+    CreateFile,
+    OptionalVersionedTextDocumentIdentifier,
+    Position,
+    Range,
+    ResourceOperationKind,
+    TextDocumentEdit,
+    TextEdit,
+    WorkspaceEdit,
+)
+from pygls.uris import to_fs_path
+from pygls.workspace import TextDocument
+
+from galaxyls.services.tools.constants import TOOL
+from galaxyls.services.tools.document import GalaxyToolXmlDocument
+from galaxyls.services.xml.document import XmlDocument
+from galaxyls.services.xml.utils import convert_document_offsets_to_range
+
+DEFAULT_MACROS_FILENAME = "macros.xml"
+
+
+class VersionTokenizeService:
+    """Code Actions that factor a literal tool version into the IUC version tokens."""
+
+    def create_version_tokenize_actions(
+        self, xml_document: XmlDocument, params: CodeActionParams
+    ) -> list[CodeAction]:
+        """The version-tokenize Code Actions available at ``params.range``, if any."""
+        if not xml_document.is_tool_file:
+            return []
+        tool = GalaxyToolXmlDocument.from_xml_document(xml_document)
+        tool_element = tool.find_element(TOOL)
+        if tool_element is None:
+            return []
+        document = xml_document.document
+        tag_range = convert_document_offsets_to_range(
+            document,
+            tool_element.start_tag_open_offset,
+            tool_element.start_tag_close_offset,
+        )
+        if not (tag_range.start.line <= params.range.start.line <= tag_range.end.line):
+            return []
+        source_path = to_fs_path(document.uri)
+        path = Path(source_path) if source_path is not None else None
+        inline = tokenize_version_plan(document.source, source_path=path)
+        if inline.bailed:
+            return []
+        actions = [self._inline_action(document, inline)]
+        separate = tokenize_version_plan(
+            document.source, source_path=path, macros_file=DEFAULT_MACROS_FILENAME
+        )
+        if not separate.bailed and separate.new_file is not None:
+            extract = self._separate_file_action(document, separate)
+            if extract is not None:
+                actions.append(extract)
+        return actions
+
+    def _text_edits(self, document: TextDocument, plan: VersionTokenPlan) -> list[TextEdit]:
+        """The plan's offset edits as document-ordered, non-overlapping ``TextEdit``s."""
+        edits = [
+            TextEdit(
+                range=convert_document_offsets_to_range(document, edit.start, edit.end),
+                new_text=edit.replacement,
+            )
+            for edit in sorted(plan.edits, key=lambda edit: edit.start)
+        ]
+        return edits
+
+    def _inline_action(self, document: TextDocument, plan: VersionTokenPlan) -> CodeAction:
+        return CodeAction(
+            title="Define @TOOL_VERSION@/@VERSION_SUFFIX@ version tokens",
+            kind=CodeActionKind.RefactorRewrite,
+            edit=WorkspaceEdit(changes={document.uri: self._text_edits(document, plan)}),
+        )
+
+    def _separate_file_action(
+        self, document: TextDocument, plan: VersionTokenPlan
+    ) -> CodeAction | None:
+        assert plan.new_file is not None  # the caller checked it
+        fs_path = to_fs_path(document.uri)
+        if fs_path is None or not Path(fs_path).is_absolute():
+            return None  # cannot resolve a sibling file URI for the new macros file
+        new_file_uri = (Path(fs_path).parent / plan.new_file.path).as_uri()
+        new_doc_position = Position(line=0, character=0)
+        document_changes: list[CreateFile | TextDocumentEdit] = [
+            CreateFile(uri=new_file_uri, kind=ResourceOperationKind.Create),
+            TextDocumentEdit(
+                text_document=OptionalVersionedTextDocumentIdentifier(
+                    uri=new_file_uri, version=0
+                ),
+                edits=[
+                    TextEdit(
+                        range=Range(start=new_doc_position, end=new_doc_position),
+                        new_text=plan.new_file.content,
+                    )
+                ],
+            ),
+            TextDocumentEdit(
+                text_document=OptionalVersionedTextDocumentIdentifier(
+                    uri=document.uri, version=document.version
+                ),
+                edits=self._text_edits(document, plan),
+            ),
+        ]
+        return CodeAction(
+            title=f"Extract version tokens to {plan.new_file.path}",
+            kind=CodeActionKind.RefactorExtract,
+            edit=WorkspaceEdit(document_changes=document_changes),
+        )

--- a/server/galaxyls/tests/unit/test_version_tokenize.py
+++ b/server/galaxyls/tests/unit/test_version_tokenize.py
@@ -1,0 +1,123 @@
+"""Tests for the version-tokenization Code Action (version_tokenize.py)."""
+
+import pytest
+
+pytest.importorskip(
+    "galaxy_tool_source.version_tokens",
+    reason="the version-tokenization engine (galaxy-tool-source >= 0.2.0) is not installed",
+)
+
+from collections.abc import Sequence  # noqa: E402
+
+from lsprotocol.types import (  # noqa: E402
+    CodeAction,
+    CodeActionContext,
+    CodeActionParams,
+    CreateFile,
+    Position,
+    Range,
+    TextDocumentEdit,
+    TextDocumentIdentifier,
+    TextEdit,
+)
+from pygls.workspace import TextDocument  # noqa: E402
+
+from galaxyls.services.tools.version_tokenize import VersionTokenizeService  # noqa: E402
+from galaxyls.tests.unit.utils import TestUtils  # noqa: E402
+
+_CANDIDATE = (
+    '<tool id="m" name="M" version="1.20+galaxy0" profile="24.0">'
+    '<requirements><requirement type="package" version="1.20">samtools</requirement>'
+    "</requirements>"
+    "<command><![CDATA[echo x]]></command>"
+    "</tool>"
+)
+
+
+def _actions(source: str, *, line: int = 0, character: int = 6) -> list[CodeAction]:
+    xml_document = TestUtils.from_source_to_xml_document(source, uri="file:///tmp/tool.xml")
+    cursor = Position(line=line, character=character)
+    params = CodeActionParams(
+        text_document=TextDocumentIdentifier(uri=xml_document.document.uri),
+        range=Range(start=cursor, end=cursor),
+        context=CodeActionContext(diagnostics=[]),
+    )
+    return VersionTokenizeService().create_version_tokenize_actions(xml_document, params)
+
+
+def _apply_text_edits(document: TextDocument, edits: Sequence[TextEdit]) -> str:
+    """Apply TextEdits to the source, highest offset first."""
+    spans = [
+        (
+            document.offset_at_position(edit.range.start),
+            document.offset_at_position(edit.range.end),
+            edit.new_text,
+        )
+        for edit in edits
+    ]
+    result = document.source
+    for start, end, new_text in sorted(spans, reverse=True):
+        result = result[:start] + new_text + result[end:]
+    return result
+
+
+def test_inline_action_offered_on_candidate() -> None:
+    actions = _actions(_CANDIDATE)
+    titles = [action.title for action in actions]
+    assert any("Define" in title and "version tokens" in title for title in titles)
+
+
+def test_inline_action_tokenizes_when_applied() -> None:
+    document = TestUtils.from_source_to_xml_document(_CANDIDATE, uri="file:///tmp/tool.xml").document
+    actions = _actions(_CANDIDATE)
+    inline = next(action for action in actions if "Define" in action.title)
+    assert inline.edit is not None and inline.edit.changes is not None
+    rendered = _apply_text_edits(document, inline.edit.changes[document.uri])
+    assert 'version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@"' in rendered
+    assert '<token name="@TOOL_VERSION@">1.20</token>' in rendered
+    assert 'version="@TOOL_VERSION@">samtools' in rendered
+
+
+def test_separate_file_action_creates_macros_file() -> None:
+    document = TestUtils.from_source_to_xml_document(_CANDIDATE, uri="file:///tmp/tool.xml").document
+    actions = _actions(_CANDIDATE)
+    extract = next(action for action in actions if "Extract" in action.title)
+    assert extract.edit is not None and extract.edit.document_changes is not None
+    changes = extract.edit.document_changes
+    create = next(change for change in changes if isinstance(change, CreateFile))
+    assert create.uri.endswith("macros.xml")
+    # The new file gets the tokens; the tool gets the import + retargeted version.
+    new_file_edit = next(
+        change
+        for change in changes
+        if isinstance(change, TextDocumentEdit) and change.text_document.uri == create.uri
+    )
+    new_file_text = new_file_edit.edits[0]
+    assert isinstance(new_file_text, TextEdit)
+    assert b'<token name="@TOOL_VERSION@">1.20</token>' in new_file_text.new_text.encode()
+    tool_edit = next(
+        change
+        for change in changes
+        if isinstance(change, TextDocumentEdit) and change.text_document.uri == document.uri
+    )
+    tool_text_edits = [edit for edit in tool_edit.edits if isinstance(edit, TextEdit)]
+    rendered = _apply_text_edits(document, tool_text_edits)
+    assert "<import>macros.xml</import>" in rendered
+    assert 'version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@"' in rendered
+
+
+def test_no_action_when_not_a_candidate() -> None:
+    plain = _CANDIDATE.replace('version="1.20+galaxy0"', 'version="1.20"')
+    assert _actions(plain) == []
+
+
+def test_no_action_when_cursor_off_the_tool_tag() -> None:
+    multiline = (
+        '<tool id="m" name="M" version="1.20+galaxy0" profile="24.0">\n'
+        '    <requirements><requirement type="package" version="1.20">samtools'
+        "</requirement></requirements>\n"
+        "    <command><![CDATA[echo x]]></command>\n"
+        "</tool>\n"
+    )
+    # Cursor on the <command> line (2), not the <tool> start tag (line 0).
+    assert _actions(multiline, line=2, character=6) == []

--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -10,3 +10,10 @@ pytest-mock==3.15.1
 pytest==9.0.3
 setuptools==82.0.1
 types-setuptools==82.0.0.20260518
+
+# Optional: the version-tokenization engine. The Code Action self-registers only when
+# this is importable, so it is NOT a runtime requirement (kept out of requirements.txt /
+# install_requires for clean published metadata; the server runs without it). Tests and
+# CI get it from here. Users who want the feature install it with:
+#   pip install galaxy-tool-source
+galaxy-tool-source==0.3.0

--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -16,4 +16,4 @@ types-setuptools==82.0.0.20260518
 # install_requires for clean published metadata; the server runs without it). Tests and
 # CI get it from here. Users who want the feature install it with:
 #   pip install galaxy-tool-source
-galaxy-tool-source==0.3.0
+galaxy-tool-source==0.3.3


### PR DESCRIPTION
Adds two **Code Actions** on a `<tool>` start tag whose `version` is a literal that can be factored into the IUC ["Tool versions"](https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html) macro convention:

- **Define version tokens** (inline) — rewrites `version="<base>+galaxy<suffix>"` to `@TOOL_VERSION@+galaxy@VERSION_SUFFIX@`, rewrites the matching package `<requirement version>` to `@TOOL_VERSION@`, and defines both tokens in an inline `<macros>` block.
- **Extract version tokens to macros.xml** — the same, but creates a new imported `macros.xml` (a `WorkspaceEdit` with a `CreateFile` resource operation + the tool edits).

Both are offered only when the version is provably tokenizable, and the edit is kept only when the resulting macro expansion is **byte-identical** to the original (the soundness gate lives in the engine, not the editor).

### Optional engine, self-registering
Like the rename/references work in #331, the feature is backed by the optional [`galaxy-tool-source`](https://pypi.org/project/galaxy-tool-source/) engine and **self-registers only when that package is importable** — the server runs normally without it (it is not a runtime requirement; it sits in `requirements-dev.txt` for tests/CI). The `tokenize_version_plan` engine API returns minimal offset-based `TextEdit`s (+ the new-file content for the extract case), so the editor emits a precise `WorkspaceEdit` with no reflow.

### Relationship to #331
This is a sibling of #331 (parameter rename/references) and a distinct, independently-reviewable feature. Both introduce the same small "optional `galaxy-tool-source` engine" plumbing (the guarded import in `language.py` + the `requirements-dev.txt` entry), so whichever merges second will need a trivial rebase on those shared lines.

### Validation
Against the published `galaxy-tool-source==0.3.0`: full unit suite green (374 passed, incl. 5 new `test_version_tokenize` tests), `ruff` + `mypy` clean. With the engine uninstalled: the server still imports, the Code Action self-unregisters, and the suite is green (the test `importorskip`s).